### PR TITLE
Provide Better Mechanism for Composing VTables

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -13,7 +13,7 @@ use common::{
     ComPtr, IClassFactory, IUnknown, CLSCTX_INPROC_SERVER, COINIT_APARTMENTTHREADED, HRESULT, IID,
     IID_ICLASS_FACTORY, LPVOID, REFCLSID, REFIID,
 };
-use server::{IAnimal, ICat, CLSID_CAT_CLASS, IExample};
+use server::{IAnimal, ICat, IExample, CLSID_CAT_CLASS};
 use std::os::raw::c_void;
 
 fn main() {
@@ -111,11 +111,9 @@ fn get_class_object(iid: &IID) -> Result<ComPtr<IClassFactory>, HRESULT> {
         return Err(hr);
     }
 
-    Ok(
-        unsafe {
-            ComPtr::new(std::ptr::NonNull::new(class_factory as *mut IClassFactory).unwrap())
-        },
-    )
+    Ok(ComPtr::new(
+        std::ptr::NonNull::new(class_factory as *mut IClassFactory).unwrap(),
+    ))
 }
 
 // TODO: accept server options
@@ -134,7 +132,9 @@ fn create_instance<T: ComInterface>(clsid: &IID) -> Result<ComPtr<T>, HRESULT> {
         return Err(hr);
     }
 
-    Ok(unsafe { ComPtr::new(std::ptr::NonNull::new(instance as *mut T).unwrap()) })
+    Ok(ComPtr::new(
+        std::ptr::NonNull::new(instance as *mut T).unwrap(),
+    ))
 }
 
 fn uninitialize() {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -3,8 +3,10 @@ mod comptr;
 
 mod iclassfactory;
 mod iunknown;
-pub use iclassfactory::{IClassFactory, IClassFactoryVTable, RawIClassFactory, IID_ICLASS_FACTORY};
-pub use iunknown::{IID_IUnknown, IUnknown, IUnknownVTable, RawIUnknown};
+pub use iclassfactory::{
+    IClassFactory, IClassFactoryMethods, IClassFactoryVTable, RawIClassFactory, IID_ICLASS_FACTORY,
+};
+pub use iunknown::{IID_IUnknown, IUnknown, IUnknownMethods, IUnknownVTable, RawIUnknown};
 
 pub use comptr::ComPtr;
 use std::os::raw::c_void;
@@ -77,7 +79,7 @@ extern "system" {
 }
 
 /// Structs implementing this trait must have the layout of a COM Interface Pointer.
-/// For example, we assume safe conversion and usage of the struct as a `RawIUnknown`. 
+/// For example, we assume safe conversion and usage of the struct as a `RawIUnknown`.
 pub unsafe trait ComInterface {
     const IID: IID;
 }

--- a/server/src/implementation/british_short_hair_cat.rs
+++ b/server/src/implementation/british_short_hair_cat.rs
@@ -1,10 +1,10 @@
 use std::os::raw::c_void;
 
 use crate::interface::{
-    ianimal::{RawIAnimal, IID_IANIMAL},
-    icat::{ICat, ICatVTable, RawICat, IID_ICAT},
+    ianimal::{IAnimalMethods, RawIAnimal, IID_IANIMAL},
+    icat::{ICat, ICatMethods, ICatVTable, RawICat, IID_ICAT},
 };
-use common::{IID_IUnknown, IUnknownVTable, RawIUnknown, E_NOINTERFACE, HRESULT, IID, NOERROR};
+use common::{IID_IUnknown, IUnknownMethods, RawIUnknown, E_NOINTERFACE, HRESULT, IID, NOERROR};
 
 /// The implementation class
 /// https://en.wikipedia.org/wiki/British_Shorthair
@@ -71,16 +71,16 @@ unsafe extern "stdcall" fn eat(_this: *mut RawIAnimal) -> HRESULT {
 impl BritishShortHairCat {
     pub(crate) fn new() -> BritishShortHairCat {
         println!("Allocating new Vtable...");
-        let iunknown = IUnknownVTable {
+        let iunknown = IUnknownMethods {
             QueryInterface: query_interface,
             Release: release,
             AddRef: add_ref,
         };
-        let vtable = Box::into_raw(Box::new(ICatVTable {
-            iunknown,
-            Eat: eat,
+        let ianimal = IAnimalMethods { Eat: eat };
+        let icat = ICatMethods {
             IgnoreHumans: ignore_humans,
-        }));
+        };
+        let vtable = Box::into_raw(Box::new(ICatVTable(iunknown, ianimal, icat)));
         let inner = RawICat { vtable };
         BritishShortHairCat {
             inner: ICat { inner },

--- a/server/src/implementation/british_short_hair_cat_class.rs
+++ b/server/src/implementation/british_short_hair_cat_class.rs
@@ -1,10 +1,12 @@
 use std::os::raw::c_void;
 
 use crate::implementation::BritishShortHairCat;
-use crate::interface::icat_class::{ICatClass, ICatClassVTable, RawICatClass, IID_ICAT_CLASS};
+use crate::interface::icat_class::{
+    ICatClass, ICatClassMethods, ICatClassVTable, RawICatClass, IID_ICAT_CLASS,
+};
 use common::{
-    IClassFactoryVTable, IID_IUnknown, IUnknownVTable, RawIUnknown, BOOL, CLASS_E_NOAGGREGATION,
-    E_NOINTERFACE, HRESULT, IID, IID_ICLASS_FACTORY, NOERROR, S_OK, RawIClassFactory
+    IClassFactoryMethods, IID_IUnknown, IUnknownMethods, RawIClassFactory, RawIUnknown, BOOL,
+    CLASS_E_NOAGGREGATION, E_NOINTERFACE, HRESULT, IID, IID_ICLASS_FACTORY, NOERROR, S_OK,
 };
 
 #[repr(C)]
@@ -82,19 +84,21 @@ unsafe extern "stdcall" fn lock_server(increment: BOOL) -> HRESULT {
 impl BritishShortHairCatClass {
     pub(crate) fn new() -> BritishShortHairCatClass {
         println!("Allocating new Vtable for CatClass...");
-        let iunknown = IUnknownVTable {
+        let iunknown = IUnknownMethods {
             QueryInterface: query_interface,
             Release: release,
             AddRef: add_ref,
         };
-        let iclassfactory = IClassFactoryVTable {
-            iunknown,
+        let iclassfactory = IClassFactoryMethods {
             CreateInstance: create_instance,
             LockServer: lock_server,
         };
-        let vtable = Box::into_raw(Box::new(ICatClassVTable {
+        let icatclass = ICatClassMethods {};
+        let vtable = Box::into_raw(Box::new(ICatClassVTable(
+            iunknown,
             iclassfactory,
-        }));
+            icatclass,
+        )));
         let inner = RawICatClass { vtable };
         BritishShortHairCatClass {
             inner: ICatClass { inner },

--- a/server/src/interface/ianimal.rs
+++ b/server/src/interface/ianimal.rs
@@ -1,5 +1,4 @@
-use super::icat::ICatVTable;
-use common::{ComInterface, ComPtr, RawIUnknown, HRESULT, IID};
+use common::{ComInterface, ComPtr, IUnknownMethods, RawIUnknown, HRESULT, IID};
 
 pub const IID_IANIMAL: IID = IID {
     data1: 0xeff8970e,
@@ -30,7 +29,7 @@ unsafe impl ComInterface for IAnimal {
 
 #[repr(C)]
 pub(crate) struct RawIAnimal {
-    vtable: *const ICatVTable,
+    vtable: *const IAnimalVTable,
 }
 
 impl RawIAnimal {
@@ -39,7 +38,7 @@ impl RawIAnimal {
     }
 
     pub unsafe fn raw_eat(&mut self) -> HRESULT {
-        ((*self.vtable).Eat)(self as *mut RawIAnimal)
+        ((*self.vtable).1.Eat)(self as *mut RawIAnimal)
     }
 }
 
@@ -53,4 +52,13 @@ impl std::convert::AsMut<RawIUnknown> for RawIAnimal {
     fn as_mut(&mut self) -> &mut RawIUnknown {
         unsafe { &mut *(self as *mut RawIAnimal as *mut RawIUnknown) }
     }
+}
+
+#[repr(C)]
+struct IAnimalVTable(IUnknownMethods, IAnimalMethods);
+
+#[allow(non_snake_case)]
+#[repr(C)]
+pub struct IAnimalMethods {
+    pub(crate) Eat: unsafe extern "stdcall" fn(*mut RawIAnimal) -> HRESULT,
 }

--- a/server/src/interface/icat.rs
+++ b/server/src/interface/icat.rs
@@ -1,5 +1,6 @@
-use super::ianimal::RawIAnimal;
-use common::{ComInterface, ComPtr, IUnknownVTable, RawIUnknown, HRESULT, IID};
+use super::ianimal::{IAnimalMethods, RawIAnimal};
+use common::{ComInterface, ComPtr, IUnknownMethods, RawIUnknown, HRESULT, IID};
+
 pub const IID_ICAT: IID = IID {
     data1: 0xf5353c58,
     data2: 0xcfd9,
@@ -39,7 +40,7 @@ pub(crate) struct RawICat {
 
 impl RawICat {
     unsafe fn raw_ignore_humans(&mut self) -> HRESULT {
-        ((*self.vtable).IgnoreHumans)(self as *mut RawICat)
+        ((*self.vtable).2.IgnoreHumans)(self as *mut RawICat)
     }
 }
 
@@ -69,8 +70,8 @@ impl std::convert::AsMut<RawIAnimal> for RawICat {
 
 #[allow(non_snake_case)]
 #[repr(C)]
-pub struct ICatVTable {
-    pub(crate) iunknown: IUnknownVTable,
-    pub(crate) Eat: unsafe extern "stdcall" fn(*mut RawIAnimal) -> HRESULT,
+pub struct ICatMethods {
     pub(crate) IgnoreHumans: unsafe extern "stdcall" fn(*mut RawICat) -> HRESULT,
 }
+#[repr(C)]
+pub struct ICatVTable(pub IUnknownMethods, pub IAnimalMethods, pub ICatMethods);

--- a/server/src/interface/icat_class.rs
+++ b/server/src/interface/icat_class.rs
@@ -1,4 +1,4 @@
-use common::{ComInterface, ComPtr, IClassFactoryVTable, RawIUnknown, IID};
+use common::{ComInterface, ComPtr, IClassFactoryMethods, IUnknownMethods, RawIUnknown, IID};
 
 pub const IID_ICAT_CLASS: IID = IID {
     data1: 0xf5353c58,
@@ -42,6 +42,10 @@ impl std::convert::AsMut<RawIUnknown> for RawICatClass {
 
 #[allow(non_snake_case)]
 #[repr(C)]
-pub struct ICatClassVTable {
-    pub(crate) iclassfactory: IClassFactoryVTable,
-}
+pub struct ICatClassMethods {}
+#[repr(C)]
+pub struct ICatClassVTable(
+    pub IUnknownMethods,
+    pub IClassFactoryMethods,
+    pub ICatClassMethods,
+);

--- a/server/src/interface/iexample.rs
+++ b/server/src/interface/iexample.rs
@@ -1,4 +1,4 @@
-use common::{ComInterface, ComPtr, RawIUnknown, HRESULT, IID, IUnknownVTable};
+use common::{ComInterface, ComPtr, IUnknownMethods, RawIUnknown, IID};
 
 pub const IID_IEXAMPLE: IID = IID {
     data1: 0xC5F45CBC,
@@ -28,8 +28,7 @@ pub(crate) struct RawIExample {
     vtable: *const IExampleVTable,
 }
 
-impl RawIExample {
-}
+impl RawIExample {}
 
 impl std::convert::AsRef<RawIUnknown> for RawIExample {
     fn as_ref(&self) -> &RawIUnknown {
@@ -43,8 +42,9 @@ impl std::convert::AsMut<RawIUnknown> for RawIExample {
     }
 }
 
+#[repr(C)]
+pub struct IExampleMethods {}
+
 #[allow(non_snake_case)]
 #[repr(C)]
-pub struct IExampleVTable {
-    pub(crate) iunknown: IUnknownVTable,
-}
+pub struct IExampleVTable(pub IUnknownMethods, pub IExampleMethods);

--- a/server/src/interface/mod.rs
+++ b/server/src/interface/mod.rs
@@ -1,9 +1,9 @@
 pub(crate) mod ianimal;
 pub(crate) mod icat;
-pub(crate) mod iexample;
 pub(crate) mod icat_class;
+pub(crate) mod iexample;
 
 pub use ianimal::IAnimal;
 pub use icat::ICat;
-pub use iexample::IExample;
 pub use icat_class::ICatClass;
+pub use iexample::IExample;


### PR DESCRIPTION
Creating VTables has been up to this point pretty difficult. It was even not possible to create VTables for two or more interfaces that shared common parent interfaces. This is because we inflated the concept of an Interface's VTable and the specific methods it provides. 

This PR breaks up those concepts. Now VTables are simple structs that compose the Methods of other interfaces. For instance: `struct ICatVTable(IUnknownMethods, IAnimalMethods, ICatMethods)`