### PR TITLE
ComPtr must be repr(C)

### DIFF
--- a/src/comptr.rs
+++ b/src/comptr.rs
@@ -7,6 +7,7 @@ use std::marker::PhantomData;
 use winapi::ctypes::c_void;
 use winapi::shared::winerror::E_NOINTERFACE;
 
+#[repr(C)]
 pub struct ComPtr<T: ?Sized + ComInterface> {
     ptr: NonNull<c_void>,
     phantom: PhantomData<T>,


### PR DESCRIPTION
We rely on being able to cast a &ComPtr to a pointer to the pointer contained as the first field. For this we need `repr(C)`. I believe `repr(transparent)` also gets us what we want, but I'm not sure which one is the right one to use in this case.