### PR TITLE
Fix IUknown typos in documentation

### DIFF
--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let unknown = factory
         .get_instance::<dyn IUnknown>()
-        .expect("Failed to get IUknown");
+        .expect("Failed to get IUnknown");
     println!("Got IUnknown");
 
     let animal = unknown

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -9,8 +9,8 @@ pub trait IUnknown {
     /// The COM [`QueryInterface` Method]
     ///
     /// This method normally should not be called directly. Interfaces that implement
-    /// `IUnknown` also implement [`IUknown::get_interface`] which is a safe wrapper around
-    /// `IUknown::query_interface`.
+    /// `IUnknown` also implement [`IUnknown::get_interface`] which is a safe wrapper around
+    /// `IUnknown::query_interface`.
     ///
     /// [`QueryInterface` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)
     /// [`IUnknown::get_interface`]: trait.IUnknown.html#method.get_interface


### PR DESCRIPTION
Just a couple of typos - although the whole trait doesn't exist anyway, so not sure how important these are. The only `get_interface` I saw implemented was on [`InterfaceRc`](https://github.com/microsoft/com-rs/blob/99112fc5a1661bb290a1f69b899ce5b046f40e70/src/interface_rc.rs#L37-L52).