### PR TITLE
Support 'unsafe' traits in com_interface

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -21,6 +21,7 @@ path = "tests/progress.rs"
 [dev-dependencies]
 trybuild = "1.0.13"
 com = { version = "0.1", path = ".." }
+winapi = "0.3"
 
 [dependencies]
 syn = { version = "1.0.5", features = ["full"] }

--- a/macros/support/src/com_interface/interface_impl.rs
+++ b/macros/support/src/com_interface/interface_impl.rs
@@ -6,6 +6,7 @@ use syn::{FnArg, ItemTrait, TraitItem, TraitItemMethod};
 
 pub fn generate(interface: &ItemTrait) -> HelperTokenStream {
     let interface_ident = &interface.ident;
+    let unsafety = &interface.unsafety;
     let mut impl_methods = Vec::new();
 
     for trait_item in &interface.items {
@@ -18,11 +19,11 @@ pub fn generate(interface: &ItemTrait) -> HelperTokenStream {
     }
 
     quote! {
-        impl <T: #interface_ident + com::ComInterface + ?Sized> #interface_ident for com::InterfaceRc<T> {
+        #unsafety impl <T: #interface_ident + com::ComInterface + ?Sized> #interface_ident for com::InterfaceRc<T> {
             #(#impl_methods)*
         }
 
-        impl <T: #interface_ident + com::ComInterface + ?Sized> #interface_ident for com::InterfacePtr<T> {
+        #unsafety impl <T: #interface_ident + com::ComInterface + ?Sized> #interface_ident for com::InterfacePtr<T> {
             #(#impl_methods)*
         }
     }

--- a/macros/tests/progress.rs
+++ b/macros/tests/progress.rs
@@ -4,4 +4,5 @@ extern crate trybuild;
 fn test_com_interface() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/no_supertrait.rs");
+    t.pass("tests/unsafe-traits.rs");
 }

--- a/macros/tests/unsafe-traits.rs
+++ b/macros/tests/unsafe-traits.rs
@@ -1,5 +1,3 @@
-// This is a compile-test to ensure the proc macro can handle unsafe traits.
-
 use com::interfaces::iunknown::IUnknown;
 use winapi::shared::winerror::NOERROR;
 
@@ -22,3 +20,5 @@ impl CoClass {
 unsafe impl IUnsafe for CoClass {
     fn method(&self) {}
 }
+
+fn main() {}

--- a/tests/unsafe-traits.rs
+++ b/tests/unsafe-traits.rs
@@ -1,0 +1,24 @@
+// This is a compile-test to ensure the proc macro can handle unsafe traits.
+
+use com::interfaces::iunknown::IUnknown;
+use winapi::shared::winerror::NOERROR;
+
+#[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+unsafe trait IUnsafe: IUnknown {
+    fn method(&self);
+}
+
+#[com::co_class(implements(IUnsafe))]
+struct CoClass {
+    data: usize,
+}
+
+impl CoClass {
+    fn new() -> Box<CoClass> {
+        CoClass::allocate(0)
+    }
+}
+
+unsafe impl IUnsafe for CoClass {
+    fn method(&self) {}
+}


### PR DESCRIPTION
The `#[com_interface]` macro didn't take the unsafety into account when implementing the traits on `InterfaceRc`/`InterfacePtr`.

One solution for the safety problem in issue #97 would be to mark the traits themselves as `unsafe`. While this does nothing to the callers, it would serve as a hint to the trait `impl` that the implementation can be called from outside of Rust's usual safety model. I was about to even suggest that `#[com_interface]` might _require_ for the traits to be marked as `unsafe`.

Also added a rudimentary compile test for this case. It might be worth it to look into an actual compile test crate, such as [trybuild](https://github.com/dtolnay/trybuild).