### PR TITLE
Run macros and macros/support tests/fmt in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,9 @@ com_macros = { version = "0.1", path = "macros" }
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
+
+[workspace]
+members = [
+    "macros",
+    "macros/support",
+]


### PR DESCRIPTION
The CI was running `cargo test` and `cargo fmt` in the root, but since the root wasn't a cargo workspace, this did nothing to the other crates (macros and macros/support).

Adding a `[workspace]` section in the `Cargo.toml` should inform cargo of these other crates and make things better in CI.

(I'm not _entirely_ sure whether this has some unwanted side effects, so I'm curious to see what the CI has to say about it.)