### PR TITLE
Define [com_interface] IID as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ COM has been superseded by [WinRT](https://docs.microsoft.com/en-us/windows/uwp/
 To both consume or produce a COM component through an interface, you will first need to generate the Rust representation of said interface. The `com_interface` macro is the main tool for automatically generating this Rust representation.
 
 ```rust
-#[com_interface(00000000-0000-0000-C000-000000000046)]
+#[com_interface("00000000-0000-0000-C000-000000000046")]
 pub trait IUnknown {
     unsafe fn query_interface(
         &self,
@@ -32,7 +32,7 @@ pub trait IUnknown {
     unsafe fn release(&self) -> u32;
 }
 
-#[com_interface(EFF8970E-C50F-45E0-9284-291CE5A6F771)]
+#[com_interface("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
 pub trait IAnimal: IUnknown {
     fn eat(&self) -> HRESULT;
 }

--- a/examples/aggregation/interface/src/ifile_manager.rs
+++ b/examples/aggregation/interface/src/ifile_manager.rs
@@ -2,7 +2,7 @@ use com::{com_interface, interfaces::iunknown::IUnknown};
 
 use winapi::shared::winerror::HRESULT;
 
-#[com_interface(25A41124-23D0-46BE-8351-044889D5E37E)]
+#[com_interface("25A41124-23D0-46BE-8351-044889D5E37E")]
 pub trait IFileManager: IUnknown {
     fn delete_all(&self) -> HRESULT;
 }

--- a/examples/aggregation/interface/src/ilocal_file_manager.rs
+++ b/examples/aggregation/interface/src/ilocal_file_manager.rs
@@ -2,7 +2,7 @@ use com::{com_interface, interfaces::iunknown::IUnknown};
 
 use winapi::shared::winerror::HRESULT;
 
-#[com_interface(4FC333E3-C389-4C48-B108-7895B0AF21AD)]
+#[com_interface("4FC333E3-C389-4C48-B108-7895B0AF21AD")]
 pub trait ILocalFileManager: IUnknown {
     fn delete_local(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/ianimal.rs
+++ b/examples/basic/interface/src/ianimal.rs
@@ -1,7 +1,7 @@
 use com::{com_interface, interfaces::iunknown::IUnknown};
 use winapi::um::winnt::HRESULT;
 
-#[com_interface(EFF8970E-C50F-45E0-9284-291CE5A6F771)]
+#[com_interface("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
 pub trait IAnimal: IUnknown {
     fn eat(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/icat.rs
+++ b/examples/basic/interface/src/icat.rs
@@ -3,7 +3,7 @@ use winapi::um::winnt::HRESULT;
 
 use crate::IAnimal;
 
-#[com_interface(F5353C58-CFD9-4204-8D92-D274C7578B53)]
+#[com_interface("F5353C58-CFD9-4204-8D92-D274C7578B53")]
 pub trait ICat: IAnimal {
     fn ignore_humans(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/icat_class.rs
+++ b/examples/basic/interface/src/icat_class.rs
@@ -1,4 +1,4 @@
 use com::{com_interface, interfaces::iclass_factory::IClassFactory};
 
-#[com_interface(F5353C58-CFD9-4204-8D92-D274C7578B53)]
+#[com_interface("F5353C58-CFD9-4204-8D92-D274C7578B53")]
 pub trait ICatClass: IClassFactory {}

--- a/examples/basic/interface/src/idomesticanimal.rs
+++ b/examples/basic/interface/src/idomesticanimal.rs
@@ -3,7 +3,7 @@ use winapi::um::winnt::HRESULT;
 
 use crate::IAnimal;
 
-#[com_interface(C22425DF-EFB2-4B85-933E-9CF7B23459E8)]
+#[com_interface("C22425DF-EFB2-4B85-933E-9CF7B23459E8")]
 pub trait IDomesticAnimal: IAnimal {
     fn train(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/iexample.rs
+++ b/examples/basic/interface/src/iexample.rs
@@ -1,4 +1,4 @@
 use com::{com_interface, interfaces::iunknown::IUnknown};
 
-#[com_interface(C5F45CBC-4439-418C-A9F9-05AC67525E43)]
+#[com_interface("C5F45CBC-4439-418C-A9F9-05AC67525E43")]
 pub trait IExample: IUnknown {}

--- a/macros/support/src/com_interface/iid.rs
+++ b/macros/support/src/com_interface/iid.rs
@@ -4,7 +4,9 @@ use quote::{format_ident, quote};
 use syn::LitInt;
 
 pub fn generate(macro_attr: &TokenStream, interface_ident: &Ident) -> HelperTokenStream {
-    let iid_value = macro_attr.to_string().replace(' ', "");
+    let iid_string: syn::LitStr =
+        syn::parse(macro_attr.clone()).expect("[com_interface] parameter must be a GUID string");
+    let iid_value = iid_string.value();
     assert!(
         iid_value.len() == 36,
         "IIDs must be exactly 36 characters long"

--- a/macros/tests/no_supertrait.rs
+++ b/macros/tests/no_supertrait.rs
@@ -1,6 +1,6 @@
 use com::com_interface;
 
-#[com_interface(cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254)]
+#[com_interface("cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254")]
 pub trait LoneInterface {
     fn do_something(&self);
     fn do_other_thing(&self);

--- a/macros/tests/no_supertrait.stderr
+++ b/macros/tests/no_supertrait.stderr
@@ -1,7 +1,7 @@
 error: custom attribute panicked
  --> $DIR/no_supertrait.rs:3:1
   |
-3 | #[com_interface(cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+3 | #[com_interface("cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254")]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: All interfaces must inherit from another COM interface

--- a/macros/tests/non_string_guid.rs
+++ b/macros/tests/non_string_guid.rs
@@ -1,0 +1,7 @@
+use com::com_interface;
+use com::interfaces::iunknown::IUnknown;
+
+#[com_interface(cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254)]
+pub trait Interface: IUnknown {}
+
+fn main() {}

--- a/macros/tests/non_string_guid.stderr
+++ b/macros/tests/non_string_guid.stderr
@@ -1,0 +1,7 @@
+error: custom attribute panicked
+ --> $DIR/non_string_guid.rs:4:1
+  |
+4 | #[com_interface(cc2d05c7-7d20-4ccb-ad75-1e7fb7c77254)]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = help: message: [com_interface] parameter must be a GUID string: Error("expected literal")

--- a/macros/tests/progress.rs
+++ b/macros/tests/progress.rs
@@ -4,5 +4,6 @@ extern crate trybuild;
 fn test_com_interface() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/no_supertrait.rs");
+    t.compile_fail("tests/non_string_guid.rs");
     t.pass("tests/supertrait_path.rs");
 }

--- a/macros/tests/supertrait_path.rs
+++ b/macros/tests/supertrait_path.rs
@@ -1,29 +1,29 @@
 mod base_absolute {
-    #[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+    #[com::com_interface("12345678-1234-1234-1234-12345678ABCD")]
     pub trait IBaseAbsolute: com::interfaces::iunknown::IUnknown {}
 }
 
 mod specific_absolute {
-    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    #[com::com_interface("12345678-1234-1234-1234-12345678ABCE")]
     trait ISpecificAbsolute: crate::base_absolute::IBaseAbsolute {}
 }
 
 mod specific_relative {
-    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    #[com::com_interface("12345678-1234-1234-1234-12345678ABCE")]
     trait ISpecificRelative: super::base_absolute::IBaseAbsolute {}
 }
 
 mod base_use {
     use com::interfaces::iunknown::IUnknown;
 
-    #[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+    #[com::com_interface("12345678-1234-1234-1234-12345678ABCD")]
     pub trait IBaseUse: IUnknown {}
 }
 
 mod specific_use {
     use crate::base_use::IBaseUse;
 
-    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    #[com::com_interface("12345678-1234-1234-1234-12345678ABCE")]
     trait ISpecificUse: IBaseUse {}
 }
 

--- a/src/interfaces/iclass_factory.rs
+++ b/src/interfaces/iclass_factory.rs
@@ -14,7 +14,7 @@ use crate::{
     ComInterface, InterfacePtr, InterfaceRc,
 };
 
-#[com_interface(00000001-0000-0000-c000-000000000046)]
+#[com_interface("00000001-0000-0000-c000-000000000046")]
 pub trait IClassFactory: IUnknown {
     unsafe fn create_instance(
         &self,

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -4,7 +4,7 @@ use winapi::{
     shared::{guiddef::REFIID, ntdef::HRESULT},
 };
 
-#[com_interface(00000000-0000-0000-C000-000000000046)]
+#[com_interface("00000000-0000-0000-C000-000000000046")]
 pub trait IUnknown {
     /// The COM [`QueryInterface` Method]
     ///


### PR DESCRIPTION
Define the GUID as a string in the `#[com_interface("<iid>")]` attributes.

Needed something easy and simple to work on. :)

Closes #90 