### PR TITLE
Replace unwraps with expect

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -35,7 +35,8 @@ fn is_aggregatable(attr_args: &AttributeArgs) -> bool {
         .find(|arg| match arg {
             NestedMeta::Meta(Meta::Path(ref path)) => {
                 let segments = &path.segments;
-                segments.len() == 1 && segments.first().unwrap().ident == "aggregatable"
+                segments.len() == 1
+                    && segments.first().expect("Invalid attribute syntax").ident == "aggregatable"
             }
             _ => false,
         })

--- a/macros/support/src/co_class/com_struct_impl.rs
+++ b/macros/support/src/co_class/com_struct_impl.rs
@@ -84,7 +84,7 @@ pub fn gen_allocate_user_fields(struct_item: &ItemStruct) -> HelperTokenStream {
         _ => panic!("Found non Named fields in struct."),
     };
     let field_idents = fields.iter().map(|field| {
-        let field_ident = field.ident.as_ref().unwrap().clone();
+        let field_ident = field.ident.as_ref().expect("Field has no ident").clone();
         quote!(#field_ident)
     });
 

--- a/macros/support/src/com_interface/com_interface_impl.rs
+++ b/macros/support/src/com_interface/com_interface_impl.rs
@@ -12,7 +12,7 @@ pub fn generate(trait_item: &ItemTrait) -> HelperTokenStream {
     let iid_check = quote! { com::_winapi::shared::guiddef::IsEqualGUID(riid, &Self::IID) };
     let recursive_iid_check = if let Some(TypeParamBound::Trait(t)) = trait_item.supertraits.first()
     {
-        let supertrait_ident = t.path.get_ident().unwrap();
+        let supertrait_ident = t.path.get_ident().expect("Path isn't ident");
         quote! { #iid_check || <dyn #supertrait_ident as com::ComInterface>::is_iid_in_inheritance_chain(riid) }
     } else {
         iid_check

--- a/macros/support/src/com_interface/vtable.rs
+++ b/macros/support/src/com_interface/vtable.rs
@@ -20,15 +20,15 @@ pub fn generate(interface: &ItemTrait) -> HelperTokenStream {
     } else {
         assert!(
             !(interface.supertraits.len() > 1),
-            "Multiple inheirtance is not supported in COM interfaces"
+            "Multiple inheritance is not supported in COM interfaces"
         );
         assert!(
             interface.supertraits.len() != 0,
             "All interfaces must inherit from another COM interface"
         );
 
-        let base_interface_ident = match interface.supertraits.first().unwrap() {
-            TypeParamBound::Trait(t) => t.path.get_ident().unwrap(),
+        let base_interface_ident = match interface.supertraits.first().expect("No supertraits") {
+            TypeParamBound::Trait(t) => t.path.get_ident().expect("Supertrait path isn't an ident"),
             _ => panic!("Unhandled super trait typeparambound"),
         };
 

--- a/macros/support/src/utils/idents.rs
+++ b/macros/support/src/utils/idents.rs
@@ -32,7 +32,14 @@ pub fn base_interface_idents(attr_args: &AttributeArgs) -> Vec<Ident> {
 
     for attr_arg in attr_args {
         if let NestedMeta::Meta(Meta::List(ref attr)) = attr_arg {
-            if attr.path.segments.last().unwrap().ident != "implements" {
+            if attr
+                .path
+                .segments
+                .last()
+                .expect("Invalid attribute syntax")
+                .ident
+                != "implements"
+            {
                 continue;
             }
 
@@ -42,7 +49,13 @@ pub fn base_interface_idents(attr_args: &AttributeArgs) -> Vec<Ident> {
                         p.segments.len() == 1,
                         "Incapable of handling multiple path segments yet."
                     );
-                    base_interface_idents.push(p.segments.last().unwrap().ident.clone());
+                    base_interface_idents.push(
+                        p.segments
+                            .last()
+                            .expect("Implemented interface is empty path")
+                            .ident
+                            .clone(),
+                    );
                 }
             }
         }
@@ -59,7 +72,14 @@ pub fn get_aggr_map(attr_args: &AttributeArgs) -> HashMap<Ident, Vec<Ident>> {
 
     for attr_arg in attr_args {
         if let NestedMeta::Meta(Meta::List(ref attr)) = attr_arg {
-            if attr.path.segments.last().unwrap().ident != "aggregates" {
+            if attr
+                .path
+                .segments
+                .last()
+                .expect("Invalid attribute syntax")
+                .ident
+                != "aggregates"
+            {
                 continue;
             }
 
@@ -76,7 +96,13 @@ pub fn get_aggr_map(attr_args: &AttributeArgs) -> HashMap<Ident, Vec<Ident>> {
                         p.segments.len() == 1,
                         "Incapable of handling multiple path segments yet."
                     );
-                    aggr_interfaces_idents.push(p.segments.last().unwrap().ident.clone());
+                    aggr_interfaces_idents.push(
+                        p.segments
+                            .last()
+                            .expect("Aggregated interface is empty path")
+                            .ident
+                            .clone(),
+                    );
                 }
             }
             let ident = aggr_interfaces_idents


### PR DESCRIPTION
Before:
```
error: custom attribute panicked
 --> $DIR/generic_coclass.rs:3:1
  |
3 | #[com_interface]
  | ^^^^^^^^^^^^^^^^
  |
  = help: message: called `Option::unwrap()` on a `None` value
```

After:
```
error: custom attribute panicked
 --> $DIR/generic_coclass.rs:3:1
  |
3 | #[crate::com_interface]
  | ^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: Supertrait path isn't an ident
```

Was playing with generic `co_class`es and getting nothing but `Option::unwrap() on None` was getting a bit annoying to debug. This should make things easier in that respect. :)

There were couple of `unwrap`s that shouldn't ever be triggered because the requirements were checked just few lines before. I opted to replace these with `expect` just in case the code changes in the future and it was more of a no brainer to use `expect` everywhere instead of having to figure out whether things could fail.

It might be worth it to enable `#[warn(clippy::option_unwrap_used)]` to avoid these in the future.