### PR TITLE
Support paths when defining supertrait for [com_interface]

### DIFF
--- a/macros/support/src/com_interface/com_interface_impl.rs
+++ b/macros/support/src/com_interface/com_interface_impl.rs
@@ -12,8 +12,7 @@ pub fn generate(trait_item: &ItemTrait) -> HelperTokenStream {
     let iid_check = quote! { com::_winapi::shared::guiddef::IsEqualGUID(riid, &Self::IID) };
     let recursive_iid_check = if let Some(TypeParamBound::Trait(t)) = trait_item.supertraits.first()
     {
-        let supertrait_ident = t.path.get_ident().expect("Path isn't ident");
-        quote! { #iid_check || <dyn #supertrait_ident as com::ComInterface>::is_iid_in_inheritance_chain(riid) }
+        quote! { #iid_check || <dyn #t as com::ComInterface>::is_iid_in_inheritance_chain(riid) }
     } else {
         iid_check
     };

--- a/macros/support/src/com_interface/vtable.rs
+++ b/macros/support/src/com_interface/vtable.rs
@@ -27,14 +27,15 @@ pub fn generate(interface: &ItemTrait) -> HelperTokenStream {
             "All interfaces must inherit from another COM interface"
         );
 
-        let base_interface_ident = match interface.supertraits.first().expect("No supertraits") {
-            TypeParamBound::Trait(t) => t.path.get_ident().expect("Supertrait path isn't an ident"),
+        let base_interface_path = match interface.supertraits.first().expect("No supertraits") {
+            TypeParamBound::Trait(path) => path,
             _ => panic!("Unhandled super trait typeparambound"),
         };
 
-        let base_field_ident = base_field_ident(&base_interface_ident.to_string());
+        let last_ident = &base_interface_path.path.segments.last().expect("Supertrait has empty path").ident;
+        let base_field_ident = base_field_ident(&last_ident.to_string());
         quote! {
-            pub #base_field_ident: <dyn #base_interface_ident as com::ComInterface>::VTable,
+            pub #base_field_ident: <dyn #base_interface_path as com::ComInterface>::VTable,
         }
     };
     let methods = gen_vtable_methods(&interface);

--- a/macros/support/src/com_interface/vtable.rs
+++ b/macros/support/src/com_interface/vtable.rs
@@ -32,7 +32,12 @@ pub fn generate(interface: &ItemTrait) -> HelperTokenStream {
             _ => panic!("Unhandled super trait typeparambound"),
         };
 
-        let last_ident = &base_interface_path.path.segments.last().expect("Supertrait has empty path").ident;
+        let last_ident = &base_interface_path
+            .path
+            .segments
+            .last()
+            .expect("Supertrait has empty path")
+            .ident;
         let base_field_ident = base_field_ident(&last_ident.to_string());
         quote! {
             pub #base_field_ident: <dyn #base_interface_path as com::ComInterface>::VTable,

--- a/macros/support/src/com_interface/vtable_macro.rs
+++ b/macros/support/src/com_interface/vtable_macro.rs
@@ -29,7 +29,8 @@ pub fn ident(struct_ident: &Ident) -> Ident {
 fn gen_parent_vtable_binding(item: &ItemStruct) -> HelperTokenStream {
     let parent = item.fields.iter().nth(0);
     if let Some(parent) = parent {
-        let is_base = parent.ident
+        let is_base = parent
+            .ident
             .as_ref()
             .map(|i| i.to_string().ends_with("_base"))
             .unwrap_or(false);
@@ -38,7 +39,10 @@ fn gen_parent_vtable_binding(item: &ItemStruct) -> HelperTokenStream {
                 syn::Type::Path(type_path) => type_path,
                 _ => panic!("vtable fields types must be type paths"),
             };
-            let qself = type_path.qself.as_ref().expect("vtable type paths must use associated types");
+            let qself = type_path
+                .qself
+                .as_ref()
+                .expect("vtable type paths must use associated types");
             let parent_ty = &qself.ty;
             return quote! {
                 let parent_vtable = <#parent_ty as com::ProductionComInterface<$class>>::vtable::<$offset>();

--- a/macros/support/src/com_interface/vtable_macro.rs
+++ b/macros/support/src/com_interface/vtable_macro.rs
@@ -27,18 +27,21 @@ pub fn ident(struct_ident: &Ident) -> Ident {
 }
 
 fn gen_parent_vtable_binding(item: &ItemStruct) -> HelperTokenStream {
-    let parent = item.fields.iter().nth(0).and_then(|f| f.ident.as_ref());
+    let parent = item.fields.iter().nth(0);
     if let Some(parent) = parent {
-        let parent = parent.to_string();
-        if parent.ends_with("_base") {
-            let parent = format_ident!(
-                "I{}",
-                crate::utils::snake_to_camel(
-                    parent.trim_end_matches("_base").trim_start_matches("i")
-                )
-            );
+        let is_base = parent.ident
+            .as_ref()
+            .map(|i| i.to_string().ends_with("_base"))
+            .unwrap_or(false);
+        if is_base {
+            let type_path = match &parent.ty {
+                syn::Type::Path(type_path) => type_path,
+                _ => panic!("vtable fields types must be type paths"),
+            };
+            let qself = type_path.qself.as_ref().expect("vtable type paths must use associated types");
+            let parent_ty = &qself.ty;
             return quote! {
-                let parent_vtable = <dyn #parent as com::ProductionComInterface<$class>>::vtable::<$offset>();
+                let parent_vtable = <#parent_ty as com::ProductionComInterface<$class>>::vtable::<$offset>();
             };
         }
     }

--- a/macros/tests/progress.rs
+++ b/macros/tests/progress.rs
@@ -4,4 +4,5 @@ extern crate trybuild;
 fn test_com_interface() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/no_supertrait.rs");
+    t.pass("tests/supertrait_path.rs");
 }

--- a/macros/tests/supertrait_path.rs
+++ b/macros/tests/supertrait_path.rs
@@ -1,5 +1,30 @@
+mod base_absolute {
+    #[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+    pub trait IBaseAbsolute: com::interfaces::iunknown::IUnknown {}
+}
 
-#[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
-trait Interface : com::interfaces::iunknown::IUnknown {}
+mod specific_absolute {
+    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    trait ISpecificAbsolute: crate::base_absolute::IBaseAbsolute {}
+}
+
+mod specific_relative {
+    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    trait ISpecificRelative: super::base_absolute::IBaseAbsolute {}
+}
+
+mod base_use {
+    use com::interfaces::iunknown::IUnknown;
+
+    #[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+    pub trait IBaseUse: IUnknown {}
+}
+
+mod specific_use {
+    use crate::base_use::IBaseUse;
+
+    #[com::com_interface(12345678-1234-1234-1234-12345678ABCE)]
+    trait ISpecificUse: IBaseUse {}
+}
 
 fn main() {}

--- a/macros/tests/supertrait_path.rs
+++ b/macros/tests/supertrait_path.rs
@@ -1,0 +1,5 @@
+
+#[com::com_interface(12345678-1234-1234-1234-12345678ABCD)]
+trait Interface : com::interfaces::iunknown::IUnknown {}
+
+fn main() {}


### PR DESCRIPTION
Instead of having to `use` the `IUnknown` everywhere, this PR adds support for:

```rust
#[com_interface(...)]
trait Foo: com::interfaces::iunknown::IUnknown {}
```

Most of the bits were very straight forward. The one places where the implementation got a bit complex (and a bit fragile) is the `#[derive(VTable)]` expansion, which used to derive the interface ident from the field name (making assumptions such as all interfaces starting with `I`) - the new implementation assumes the type is defined as an associated type of the original interface:

```rust
  <dyn path::to::some::Interface as ...>::VTable
// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use this
```

This branch is in a conflict with #108 and will fail to build with #107. I'll merge things around once I have a better idea what PRs will land and in which order.