### PR TITLE
Support generic co_classes

### DIFF
--- a/macros/support/src/aggr_co_class/com_struct_impl.rs
+++ b/macros/support/src/aggr_co_class/com_struct_impl.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as HelperTokenStream;
 use quote::quote;
 use std::collections::HashMap;
-use syn::{Ident, ItemStruct};
+use syn::{parse_quote, Ident, ItemStruct};
 
 /// Generates the methods that the com struct needs to have. These include:
 /// allocate: To initialise the vtables, including the non_delegatingegating_iunknown one.
@@ -83,6 +83,7 @@ pub fn gen_inner_release(
     aggr_map: &HashMap<Ident, Vec<Ident>>,
     struct_ident: &Ident,
 ) -> HelperTokenStream {
+    let struct_type = parse_quote!(#struct_ident);
     let ref_count_ident = crate::utils::ref_count_ident();
 
     let release_decrement = crate::co_class::iunknown_impl::gen_release_decrement(&ref_count_ident);
@@ -96,7 +97,7 @@ pub fn gen_inner_release(
     let release_drops = crate::co_class::iunknown_impl::gen_release_drops(
         base_interface_idents,
         aggr_map,
-        struct_ident,
+        &struct_type,
     );
     let non_delegating_iunknown_drop = gen_non_delegating_iunknown_drop();
 
@@ -163,9 +164,10 @@ fn gen_allocate_fn(
     struct_item: &ItemStruct,
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let struct_type = parse_quote!(#struct_ident);
 
     let base_inits = crate::co_class::com_struct_impl::gen_allocate_base_inits(
-        struct_ident,
+        &struct_type,
         base_interface_idents,
     );
 

--- a/macros/support/src/co_class/class_factory.rs
+++ b/macros/support/src/co_class/class_factory.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, TokenStream as HelperTokenStream};
 use quote::{format_ident, quote};
 use std::collections::HashMap;
-use syn::ItemStruct;
+use syn::{parse_quote, ItemStruct};
 
 fn get_iclass_factory_interface_ident() -> Ident {
     format_ident!("IClassFactory")
@@ -112,6 +112,7 @@ pub fn gen_release(
     aggr_map: &HashMap<Ident, Vec<Ident>>,
     struct_ident: &Ident,
 ) -> HelperTokenStream {
+    let struct_type = parse_quote!(#struct_ident);
     let ref_count_ident = crate::utils::ref_count_ident();
 
     let release_decrement = super::iunknown_impl::gen_release_decrement(&ref_count_ident);
@@ -122,7 +123,7 @@ pub fn gen_release(
     let release_new_count_var_zero_check =
         super::iunknown_impl::gen_new_count_var_zero_check(&ref_count_ident);
     let release_drops =
-        super::iunknown_impl::gen_release_drops(base_interface_idents, aggr_map, struct_ident);
+        super::iunknown_impl::gen_release_drops(base_interface_idents, aggr_map, &struct_type);
 
     quote! {
         unsafe fn release(&self) -> u32 {
@@ -166,8 +167,9 @@ pub fn gen_class_factory_impl(
 ) -> HelperTokenStream {
     let ref_count_field = super::com_struct_impl::gen_allocate_ref_count_field();
     let base_fields = super::com_struct_impl::gen_allocate_base_fields(base_interface_idents);
+    let class_factory_type = parse_quote!(#class_factory_ident);
     let base_inits =
-        super::com_struct_impl::gen_allocate_base_inits(class_factory_ident, base_interface_idents);
+        super::com_struct_impl::gen_allocate_base_inits(&class_factory_type, base_interface_idents);
 
     quote! {
         impl #class_factory_ident {

--- a/macros/support/src/co_class/co_class_impl.rs
+++ b/macros/support/src/co_class/co_class_impl.rs
@@ -4,9 +4,11 @@ use syn::ItemStruct;
 
 pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (impl_generics, ty_generics, where_clause) = struct_item.generics.split_for_impl();
 
     quote! {
-        unsafe impl com::CoClass for #struct_ident {
+        unsafe impl #impl_generics com::CoClass
+        for #struct_ident #ty_generics #where_clause {
         }
     }
 }

--- a/macros/support/src/co_class/com_struct.rs
+++ b/macros/support/src/co_class/com_struct.rs
@@ -17,6 +17,7 @@ pub fn generate(
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
     let vis = &struct_item.vis;
+    let (_, ty_generics, where_clause) = struct_item.generics.split_for_impl();
 
     let base_fields = gen_base_fields(base_interface_idents);
     let ref_count_field = gen_ref_count_field();
@@ -25,7 +26,7 @@ pub fn generate(
 
     quote!(
         #[repr(C)]
-        #vis struct #struct_ident {
+        #vis struct #struct_ident #ty_generics #where_clause {
             #base_fields
             #ref_count_field
             #aggregate_fields

--- a/macros/support/src/co_class/com_struct_impl.rs
+++ b/macros/support/src/co_class/com_struct_impl.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream as HelperTokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashMap;
-use syn::{Fields, Ident, ItemStruct};
+use syn::{parse_quote, Fields, Ident, ItemStruct, Type};
 
 pub fn generate(
     aggr_map: &HashMap<Ident, Vec<Ident>>,
@@ -9,13 +9,14 @@ pub fn generate(
     struct_item: &ItemStruct,
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (impl_generics, ty_generics, where_clause) = struct_item.generics.split_for_impl();
 
     let allocate_fn = gen_allocate_fn(aggr_map, base_interface_idents, struct_item);
     let set_aggregate_fns = gen_set_aggregate_fns(aggr_map);
     let get_class_object_fn = gen_get_class_object_fn(struct_item);
 
     quote!(
-        impl #struct_ident {
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
             #allocate_fn
             #get_class_object_fn
             #set_aggregate_fns
@@ -30,8 +31,10 @@ pub fn gen_allocate_fn(
     struct_item: &ItemStruct,
 ) -> HelperTokenStream {
     let struct_ident = &struct_item.ident;
+    let (_, ty_generics, _) = struct_item.generics.split_for_impl();
+    let struct_type = parse_quote!(#struct_ident #ty_generics);
 
-    let base_inits = gen_allocate_base_inits(struct_ident, base_interface_idents);
+    let base_inits = gen_allocate_base_inits(&struct_type, base_interface_idents);
 
     // Allocate function signature
     let allocate_parameters = gen_allocate_function_parameters_signature(struct_item);
@@ -44,7 +47,7 @@ pub fn gen_allocate_fn(
 
     // Initialise all aggregated objects as NULL.
     quote!(
-        fn allocate(#allocate_parameters) -> Box<#struct_ident> {
+        fn allocate(#allocate_parameters) -> Box<#struct_ident #ty_generics> {
             #base_inits
 
             let out = #struct_ident {
@@ -111,7 +114,7 @@ pub fn gen_allocate_base_fields(base_interface_idents: &[Ident]) -> HelperTokenS
 
 // Initialise VTables with the correct adjustor thunks, through the vtable! macro.
 pub fn gen_allocate_base_inits(
-    struct_ident: &Ident,
+    struct_type: &Type,
     base_interface_idents: &[Ident],
 ) -> HelperTokenStream {
     let mut offset_count: usize = 0;
@@ -120,7 +123,7 @@ pub fn gen_allocate_base_inits(
         let vptr_field_ident = crate::utils::vptr_field_ident(&base);
 
         let out = quote!(
-            let #vtable_var_ident = com::vtable!(#struct_ident: #base, #offset_count);
+            let #vtable_var_ident = com::vtable!(#struct_type: #base, #offset_count);
             let #vptr_field_ident = Box::into_raw(Box::new(#vtable_var_ident));
         );
 
@@ -134,6 +137,11 @@ pub fn gen_allocate_base_inits(
 /// Function used by in-process DLL macro to get an instance of the
 /// class object.
 pub fn gen_get_class_object_fn(struct_item: &ItemStruct) -> HelperTokenStream {
+    // Generic structs don't have class objects so we'll return an empty token stream for those.
+    if struct_item.generics.lt_token.is_some() {
+        return quote!();
+    }
+
     let struct_ident = &struct_item.ident;
     let class_factory_ident = crate::utils::class_factory_ident(&struct_ident);
 

--- a/macros/support/src/co_class/mod.rs
+++ b/macros/support/src/co_class/mod.rs
@@ -20,7 +20,13 @@ pub fn expand_co_class(input: &ItemStruct, attr_args: &AttributeArgs) -> TokenSt
     );
     out.push(co_class_impl::generate(input).into());
     out.push(iunknown_impl::generate(&base_interface_idents, &aggr_interface_idents, input).into());
-    out.push(class_factory::generate(input).into());
+
+    // Generate class factory only for non-generic structs.
+    // We are using the presence of the '<' token in the struct generics to
+    // detect if the struct is a generic struct or not.
+    if input.generics.lt_token.is_none() {
+        out.push(class_factory::generate(input).into());
+    }
 
     TokenStream::from_iter(out)
 }

--- a/macros/tests/generic_co_class.rs
+++ b/macros/tests/generic_co_class.rs
@@ -1,0 +1,25 @@
+use com::interfaces::iunknown::IUnknown;
+use com::*;
+use std::fmt::Display;
+
+#[com_interface("12345678-1234-1234-1234-12345678ABCD")]
+trait IInterface: IUnknown {
+    fn default_length(&self) -> usize;
+    fn value_length(&self) -> usize;
+}
+
+#[co_class(implements(IInterface))]
+pub struct CoClass<T: Default + Display> {
+    value: T,
+}
+
+impl<T: Default + Display> IInterface for CoClass<T> {
+    fn default_length(&self) -> usize {
+        T::default().to_string().len()
+    }
+    fn value_length(&self) -> usize {
+        self.value.to_string().len()
+    }
+}
+
+fn main() {}

--- a/macros/tests/progress.rs
+++ b/macros/tests/progress.rs
@@ -6,4 +6,5 @@ fn test_com_interface() {
     t.compile_fail("tests/no_supertrait.rs");
     t.compile_fail("tests/non_string_guid.rs");
     t.pass("tests/supertrait_path.rs");
+    t.pass("tests/generic_co_class.rs");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,21 +42,21 @@ pub trait ProductionComInterface<T: IUnknown>: ComInterface {
 
 #[macro_export]
 macro_rules! vtable {
-    ($class:ident: $interface:ident, $offset:ident) => {
+    ($class:ty: $interface:ident, $offset:ident) => {
         <dyn $interface as $crate::ProductionComInterface<$class>>::vtable::<
             $crate::offset::$offset,
         >();
     };
-    ($class:ident: $interface:ident, 2usize) => {
+    ($class:ty: $interface:ident, 2usize) => {
         $crate::vtable!($class: $interface, Two)
     };
-    ($class:ident: $interface:ident, 1usize) => {
+    ($class:ty: $interface:ident, 1usize) => {
         $crate::vtable!($class: $interface, One)
     };
-    ($class:ident: $interface:ident, 0usize) => {
+    ($class:ty: $interface:ident, 0usize) => {
         $crate::vtable!($class: $interface, Zero)
     };
-    ($class:ident: $interface:ident) => {
+    ($class:ty: $interface:ident) => {
         $crate::vtable!($class: $interface, Zero)
     };
 }


### PR DESCRIPTION
Support specifying `#[com_class]` on generic structs. This is mostly aiming for the generalized class object of #32, but I can come up with other use cases as well, such as `IStream` implementations that owns a strongly typed container of items to stream from.

In the end I'm not too sure how useful this is on its own. Neither of the two use cases is currently supported anyway:
- #32 using this for the class factory
- Using generic co_classes to implement interfaces would need #96 to be able to create the classes and return them by interface.

Like mentioned in #109, the implementation omits class factory construction. Also the support isn't extended to the aggregatable co_classes. Given generic structs can't be constructed with `CoCreateInstance`, would there still be a use case for these with aggregatable classes?