### PR TITLE
Require `unsafe`

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,13 +1,156 @@
 # Safety
 
-COM specifies very little in the way of memory safety of COM based APIs. It is left up to the programmer to verify APIs and to make safe wrappers for them.
+COM specifies very little in the way of memory safety of COM based APIs. It is left up to
+ the programmer to verify APIs and to make safe wrappers for them.
 
 ## The `unsafe` Keyword
 
-While it is not a requirement for the methods of a `com_interface` to marked as `unsafe`, it is generally a good idea to do so unless there is no way for that method to be called in an unsafe way.
+It is a requirement for all methods of a `com_interface` to be marked as `unsafe`. This is required since at the time of declaring an interface, there is no way to ensure that any call to that interface will meet all of Rust's safety expectations. 
 
 ## `&self`, `&mut self`, and `self`
 
-All methods of a `com_interface` are required to take an unexclusive reference to self (`&self`). This reflects the reality that COM interfaces do not have exclusive access to the underlying class,
-and it does not take ownership (i.e., it is not responsible for the destruction) of the underlying class. As such if you're implementing a COM server, you will most likely need to use [interior
-mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) if you would like to mutate state in method calls.
+All methods of a `com_interface` are required to take an unexclusive reference to self 
+(`&self`). This reflects the reality that COM interfaces do not have exclusive access to 
+the underlying class,and it does not take ownership (i.e., it is not responsible for the 
+destruction) of the underlying class. As such if you're implementing a COM server, you 
+will most likely need to use [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) 
+if you would like to mutate state in method calls.
+
+## Example
+
+In order to understand the safety properties of a COM interface in Rust, it's easiest to 
+look at an example. We'll try to declare a minimum COM interface. This interface will 
+seemingly do very little, but we'll explore what the programmer must ensure for this
+interface to be safe.
+
+```rust
+#[com_interface("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
+pub trait IAnimal: IUnknown {
+    unsafe fn eat(&self) -> HRESULT;
+}
+```
+
+`IAnimal` is a minimal COM interface that only adds one method on top of the three methods 
+defined by `IUnknown`.
+
+This interface will expand to the following code.
+
+```rust 
+pub mod ianimal {
+    use com::{com_interface, interfaces::iunknown::IUnknown};
+    use winapi::um::winnt::HRESULT;
+
+    // Redeclaration of the trait
+    pub trait IAnimal: IUnknown {
+        unsafe fn eat(&self) -> HRESULT;
+    }
+
+    // The VTable for the IAnimal interface
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    pub struct IAnimalVTable {
+        pub iunknown_base: <dyn IUnknown as com::ComInterface>::VTable,
+        pub Eat: unsafe extern "stdcall" fn(*mut IAnimalVPtr) -> HRESULT,
+    }
+
+    pub type IAnimalVPtr = *const IAnimalVTable;
+
+    // Allowing `eat` to be called on on an `InterfaceRc<dyn IAnimal>`
+    impl<T: IAnimal + com::ComInterface + ?Sized> IAnimal for com::InterfaceRc<T> {
+        unsafe fn eat(&self) -> HRESULT {
+            let interface_ptr = self.as_raw() as *mut IAnimalVPtr;
+            ((**interface_ptr).Eat)(interface_ptr)
+        }
+    }
+
+    // Allowing `eat` to be called on on an `InterfacePtr<dyn IAnimal>`
+    impl<T: IAnimal + com::ComInterface + ?Sized> IAnimal for com::InterfacePtr<T> {
+        unsafe fn eat(&self) -> HRESULT {
+            let interface_ptr = self.as_raw() as *mut IAnimalVPtr;
+            ((**interface_ptr).Eat)(interface_ptr)
+        }
+    }
+
+    // Declaration that IAnimal is a COM Interface
+    unsafe impl com::ComInterface for dyn IAnimal {
+        type VTable = IAnimalVTable;
+        const IID: com::_winapi::shared::guiddef::IID = IID_IANIMAL;
+        fn is_iid_in_inheritance_chain(riid: &com::_winapi::shared::guiddef::IID) -> bool {
+            com::_winapi::shared::guiddef::IsEqualGUID(riid, &Self::IID)
+                || <dyn IUnknown as com::ComInterface>::is_iid_in_inheritance_chain(riid)
+        }
+    }
+
+    impl<C: IAnimal> com::ProductionComInterface<C> for dyn IAnimal {
+        fn vtable<O: com::offset::Offset>() -> Self::VTable {
+            {
+                let parent_vtable = <dyn IUnknown com::ProductionComInterface<C>>::vtable::<O>();
+
+                // The actual real call to some `eat` COM method
+                unsafe extern "stdcall" fn ianimal_eat<C: IAnimal, O: com::offset::Offset>(
+                    arg0: *mut IAnimalVPtr,
+                ) -> HRESULT {
+                    let this = arg0.sub(O::VALUE) as *const C as *mut C;
+                    (*this).eat()
+                }
+
+                IAnimalVTable {
+                    iunknown_base: parent_vtable,
+                    Eat: ianimal_eat::<C, O>,
+                }
+            }
+        }
+    }
+    #[allow(non_upper_case_globals)]
+    pub const IID_IANIMAL: com::_winapi::shared::guiddef::GUID =
+        com::_winapi::shared::guiddef::GUID {
+            Data1: 0xEFF8970E,
+            Data2: 0xC50F,
+            Data3: 0x45E0,
+            Data4: [0x92, 0x84, 0x29, 0x1C, 0xE5, 0xA6, 0xF7, 0x71],
+        };
+}
+```
+
+
+There's a few occasions where we're going outside of the Rust type system and relying that the 
+programmer has verified everything will be ok. 
+
+The first we should look at is where we implement `IAnimal` for `InterfaceRc<dyn IAnimal>` and `InterfacePtr<dyn IAnimal>`:
+
+```rust
+impl<T: IAnimal + com::ComInterface + ?Sized> IAnimal for com::InterfaceRc<T> {
+        unsafe fn eat(&self) -> HRESULT {
+            let interface_ptr = self.as_raw() as *mut IAnimalVPtr;
+            ((**interface_ptr).Eat)(interface_ptr)
+        }
+    }
+
+    // Allowing `eat` to be called on on an `InterfacePtr<dyn IAnimal>`
+    impl<T: IAnimal + com::ComInterface + ?Sized> IAnimal for com::InterfacePtr<T> {
+        unsafe fn eat(&self) -> HRESULT {
+            let interface_ptr = self.as_raw() as *mut IAnimalVPtr;
+            ((**interface_ptr).Eat)(interface_ptr)
+        }
+    }
+```
+
+Here we are casting whatever pointer the `InterfaceRc` or `InterfacePtr` is holding on to
+as an `*mut IAnimalVPtr` or in other words a `*mut *const IAnimalVTable`. When working 
+with raw pointers there are several things we need to sure in order to verify it's safe usage
+within Rust:
+* The pointer is non null
+* The pointer is pointing to valid data
+* The pointer is not aliased for longer than the lifetime of `&self`. In other words, you can alias
+the pointer but only for as long as `&self` lives. 
+* The contents pointed are not mutated if there are other readers of `&self`. In other words, because we have non-exclusive access, we are not allowed to mutate the contents the pointer is pointing to. If we cannot be sure about this at compile time we should wrap this interface in an `Rc`.
+
+The first two points should be verified in other parts of the code. The `InterfaceRc` and `InterfacePtr` 
+types should only be constructed if the first two points hold. If they do not hold, then some code 
+somewhere else is incorrect.
+
+The last two points cannot really be known until the point we call `InterfaceRc<dyn IAnimal>::eat`. It 
+is up to the programmer at the time of calling to ensure that these two points will hold. This is why
+it the method is marked as `unsafe`. Only the programmer who is writing the code where the interface method
+can be called has any possibility of verifying these rules. If they cannot be verified than the programmer
+should use some runtime constructs like `Rc` to ensure this is the case. 

--- a/examples/aggregation/client/src/main.rs
+++ b/examples/aggregation/client/src/main.rs
@@ -13,17 +13,17 @@ fn main() {
         .create_instance::<dyn IFileManager>(&CLSID_WINDOWS_FILE_MANAGER_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get file manager{:x}", hr));
     println!("Got filemanager!");
-    file_manager.delete_all();
+    unsafe { file_manager.delete_all() };
 
     let local_file_manager = file_manager
         .get_interface::<dyn ILocalFileManager>()
         .expect("Failed to get local file manager");
     println!("Got local lile lanager.");
-    local_file_manager.delete_local();
+    unsafe { local_file_manager.delete_local() };
 
     let local_file_manager = runtime
         .create_instance::<dyn ILocalFileManager>(&CLSID_LOCAL_FILE_MANAGER_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get local file manager{:x}", hr));
     println!("Got localfilemanager!");
-    local_file_manager.delete_local();
+    unsafe { local_file_manager.delete_local() };
 }

--- a/examples/aggregation/interface/src/ifile_manager.rs
+++ b/examples/aggregation/interface/src/ifile_manager.rs
@@ -4,5 +4,5 @@ use winapi::shared::winerror::HRESULT;
 
 #[com_interface("25A41124-23D0-46BE-8351-044889D5E37E")]
 pub trait IFileManager: IUnknown {
-    fn delete_all(&self) -> HRESULT;
+    unsafe fn delete_all(&self) -> HRESULT;
 }

--- a/examples/aggregation/interface/src/ilocal_file_manager.rs
+++ b/examples/aggregation/interface/src/ilocal_file_manager.rs
@@ -4,5 +4,5 @@ use winapi::shared::winerror::HRESULT;
 
 #[com_interface("4FC333E3-C389-4C48-B108-7895B0AF21AD")]
 pub trait ILocalFileManager: IUnknown {
-    fn delete_local(&self) -> HRESULT;
+    unsafe fn delete_local(&self) -> HRESULT;
 }

--- a/examples/aggregation/server/src/local_file_manager.rs
+++ b/examples/aggregation/server/src/local_file_manager.rs
@@ -11,7 +11,7 @@ pub struct LocalFileManager {
 }
 
 impl ILocalFileManager for LocalFileManager {
-    fn delete_local(&self) -> HRESULT {
+    unsafe fn delete_local(&self) -> HRESULT {
         println!("Deleting Locally...");
         NOERROR
     }

--- a/examples/aggregation/server/src/windows_file_manager.rs
+++ b/examples/aggregation/server/src/windows_file_manager.rs
@@ -16,7 +16,7 @@ pub struct WindowsFileManager {
 }
 
 impl IFileManager for WindowsFileManager {
-    fn delete_all(&self) -> HRESULT {
+    unsafe fn delete_all(&self) -> HRESULT {
         println!("Deleting all by delegating to Local and Remote File Managers...");
         NOERROR
     }

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
         .expect("Failed to get IAnimal");
     println!("Got IAnimal");
 
-    animal.eat();
+    unsafe { animal.eat() };
 
     // Test cross-vtable interface queries for both directions.
     let domestic_animal = animal
@@ -28,27 +28,27 @@ fn main() {
         .expect("Failed to get IDomesticAnimal");
     println!("Got IDomesticAnimal");
 
-    domestic_animal.train();
+    unsafe { domestic_animal.train() };
 
     let new_cat = domestic_animal
         .get_interface::<dyn ICat>()
         .expect("Failed to get ICat");
     println!("Got ICat");
-    new_cat.ignore_humans();
+    unsafe { new_cat.ignore_humans() };
 
     // Test querying within second vtable.
     let domestic_animal_two = domestic_animal
         .get_interface::<dyn IDomesticAnimal>()
         .expect("Failed to get second IDomesticAnimal");
     println!("Got IDomesticAnimal");
-    domestic_animal_two.train();
+    unsafe { domestic_animal_two.train() };
 
     let cat = runtime
         .create_instance::<dyn ICat>(&CLSID_CAT_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get a cat {:x}", hr));
     println!("Got another cat");
 
-    cat.eat();
+    unsafe { cat.eat() };
 
     assert!(animal.get_interface::<dyn ICat>().is_some());
     assert!(animal.get_interface::<dyn IUnknown>().is_some());

--- a/examples/basic/interface/src/ianimal.rs
+++ b/examples/basic/interface/src/ianimal.rs
@@ -3,5 +3,5 @@ use winapi::um::winnt::HRESULT;
 
 #[com_interface("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
 pub trait IAnimal: IUnknown {
-    fn eat(&self) -> HRESULT;
+    unsafe fn eat(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/icat.rs
+++ b/examples/basic/interface/src/icat.rs
@@ -5,5 +5,5 @@ use crate::IAnimal;
 
 #[com_interface("F5353C58-CFD9-4204-8D92-D274C7578B53")]
 pub trait ICat: IAnimal {
-    fn ignore_humans(&self) -> HRESULT;
+    unsafe fn ignore_humans(&self) -> HRESULT;
 }

--- a/examples/basic/interface/src/idomesticanimal.rs
+++ b/examples/basic/interface/src/idomesticanimal.rs
@@ -5,5 +5,5 @@ use crate::IAnimal;
 
 #[com_interface("C22425DF-EFB2-4B85-933E-9CF7B23459E8")]
 pub trait IDomesticAnimal: IAnimal {
-    fn train(&self) -> HRESULT;
+    unsafe fn train(&self) -> HRESULT;
 }

--- a/examples/basic/server/src/british_short_hair_cat.rs
+++ b/examples/basic/server/src/british_short_hair_cat.rs
@@ -12,21 +12,21 @@ pub struct BritishShortHairCat {
 }
 
 impl IDomesticAnimal for BritishShortHairCat {
-    fn train(&self) -> HRESULT {
+    unsafe fn train(&self) -> HRESULT {
         println!("Training...");
         NOERROR
     }
 }
 
 impl ICat for BritishShortHairCat {
-    fn ignore_humans(&self) -> HRESULT {
+    unsafe fn ignore_humans(&self) -> HRESULT {
         println!("Ignoring Humans...");
         NOERROR
     }
 }
 
 impl IAnimal for BritishShortHairCat {
-    fn eat(&self) -> HRESULT {
+    unsafe fn eat(&self) -> HRESULT {
         println!("Eating...");
         NOERROR
     }

--- a/macros/support/src/aggr_co_class/iunknown_impl.rs
+++ b/macros/support/src/aggr_co_class/iunknown_impl.rs
@@ -21,7 +21,7 @@ pub fn generate(struct_item: &ItemStruct) -> HelperTokenStream {
                 iunknown_to_use.query_interface(riid, ppv)
             }
 
-            fn add_ref(&self) -> u32 {
+            unsafe fn add_ref(&self) -> u32 {
                 let iunknown_to_use  = unsafe { com::InterfacePtr::<dyn com::interfaces::iunknown::IUnknown>::new(self.#iunknown_to_use_field_ident #ptr_casting) };
                 iunknown_to_use.add_ref()
             }

--- a/macros/support/src/co_class/class_factory.rs
+++ b/macros/support/src/co_class/class_factory.rs
@@ -84,7 +84,7 @@ pub fn gen_class_factory_struct_definition(class_factory_ident: &Ident) -> Helpe
 pub fn gen_lock_server() -> HelperTokenStream {
     quote! {
         // TODO: Implement correctly
-        fn lock_server(&self, _increment: com::_winapi::shared::minwindef::BOOL) -> com::_winapi::shared::winerror::HRESULT {
+        unsafe fn lock_server(&self, _increment: com::_winapi::shared::minwindef::BOOL) -> com::_winapi::shared::winerror::HRESULT {
             com::_winapi::shared::winerror::S_OK
         }
     }

--- a/macros/support/src/co_class/iunknown_impl.rs
+++ b/macros/support/src/co_class/iunknown_impl.rs
@@ -30,7 +30,7 @@ pub fn gen_add_ref() -> HelperTokenStream {
     let add_ref_implementation = gen_add_ref_implementation();
 
     quote! {
-        fn add_ref(&self) -> u32 {
+        unsafe fn add_ref(&self) -> u32 {
             #add_ref_implementation
         }
     }

--- a/macros/support/src/co_class/mod.rs
+++ b/macros/support/src/co_class/mod.rs
@@ -15,10 +15,13 @@ pub fn expand_co_class(input: &ItemStruct, attr_args: &AttributeArgs) -> TokenSt
 
     let mut out: Vec<TokenStream> = Vec::new();
     out.push(com_struct::generate(&aggr_interface_idents, &base_interface_idents, input).into());
+
     out.push(
         com_struct_impl::generate(&aggr_interface_idents, &base_interface_idents, input).into(),
     );
+
     out.push(co_class_impl::generate(input).into());
+
     out.push(iunknown_impl::generate(&base_interface_idents, &aggr_interface_idents, input).into());
     out.push(class_factory::generate(input).into());
 

--- a/macros/support/src/com_interface/interface_impl.rs
+++ b/macros/support/src/com_interface/interface_impl.rs
@@ -49,7 +49,7 @@ fn gen_impl_method(interface_ident: &Ident, method: &TraitItemMethod) -> HelperT
     quote!(
         #method_sig {
             let #interface_ptr_ident = self.as_raw() as *mut #vptr_ident;
-            unsafe { ((**#interface_ptr_ident).#method_ident)(#(#params),*) }
+            ((**#interface_ptr_ident).#method_ident)(#(#params),*)
         }
     )
 }

--- a/macros/support/src/com_interface/vtable.rs
+++ b/macros/support/src/com_interface/vtable.rs
@@ -79,6 +79,10 @@ fn gen_vtable_methods(interface: &ItemTrait) -> HelperTokenStream {
 }
 
 fn gen_vtable_method(interface_ident: &Ident, method: &TraitItemMethod) -> HelperTokenStream {
+    assert!(
+        method.sig.unsafety.is_some(),
+        "COM Interface methods must be declared unsafe"
+    );
     let method_ident = format_ident!(
         "{}",
         crate::utils::snake_to_camel(&method.sig.ident.to_string())
@@ -105,6 +109,7 @@ fn gen_vtable_function_signature(
 fn gen_raw_params(interface_ident: &Ident, method: &TraitItemMethod) -> HelperTokenStream {
     let mut params = Vec::new();
     let vptr_ident = vptr::ident(&interface_ident.to_string());
+
     for param in method.sig.inputs.iter() {
         match param {
             FnArg::Receiver(s) => {

--- a/src/inproc.rs
+++ b/src/inproc.rs
@@ -175,9 +175,12 @@ pub fn initialize_class_object<T: IUnknown>(
     riid: REFIID,
     ppv: *mut LPVOID,
 ) -> HRESULT {
-    instance.add_ref();
-    let hr = unsafe { instance.query_interface(riid, ppv) };
-    unsafe { instance.release() };
+    let hr = unsafe {
+        instance.add_ref();
+        let hr = instance.query_interface(riid, ppv);
+        instance.release();
+        hr
+    };
     Box::into_raw(instance);
 
     hr

--- a/src/interfaces/iclass_factory.rs
+++ b/src/interfaces/iclass_factory.rs
@@ -22,7 +22,7 @@ pub trait IClassFactory: IUnknown {
         riid: REFIID,
         ppv: *mut *mut c_void,
     ) -> HRESULT;
-    fn lock_server(&self, increment: BOOL) -> HRESULT;
+    unsafe fn lock_server(&self, increment: BOOL) -> HRESULT;
 }
 
 impl InterfaceRc<dyn IClassFactory> {

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -23,7 +23,7 @@ pub trait IUnknown {
     ///
     /// [`AddRef` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref
     /// [`InterfaceRc`]: struct.InterfaceRc.html
-    fn add_ref(&self) -> u32;
+    unsafe fn add_ref(&self) -> u32;
 
     /// The COM [`Release` Method]
     ///


### PR DESCRIPTION
As a partial solution to #97. 

Hopefully the new docs add some explanation as to why. This requires all COM interface methods to be marked `unsafe`. The short and sweet reason for this is that it is always possible that a COM interface implementation can do something that will violate Rust's safety rules but still be a valid COM interface. Because of this, we require the caller of every COM interface method to verify that calling the method does not violate Rust's safety rules. 