### PR TITLE
Improve the two Interface pointers

### DIFF
--- a/src/interface_ptr.rs
+++ b/src/interface_ptr.rs
@@ -12,6 +12,7 @@ use std::ptr::NonNull;
 /// automatically calls `AddRef` and `Release` at the right time .
 ///
 /// [`InterfaceRc`]: struct.InterfaceRc.html
+#[repr(transparent)]
 pub struct InterfacePtr<T: ?Sized + ComInterface> {
     ptr: NonNull<*mut <T as ComInterface>::VTable>,
     phantom: PhantomData<T>,

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,2 +1,5 @@
 pub mod iclass_factory;
 pub mod iunknown;
+
+pub use iclass_factory::IClassFactory;
+pub use iunknown::IUnknown;


### PR DESCRIPTION
This addresses most of the issues in #99. 

`InterfacePtr` should only be constructed if `AddRef` was called on the underlying interface before the raw pointer is moved into `InterfacePtr::new`. The documentation of `InterfacePtr::new` now reflects this. It is up to the user to ensure that `Release` gets called when that `InterfacePtr` is no longer needed. This is usually done by converting `InterfacePtr` to an `InterfaceRc` through the `InterfacePtr::upgrade` method. 

These changes make it possible to leak memory but not to violate safety rules unless some invariant is not held when calling an `unsafe` function. 

Clone on `InterfacePtr` now correctly calls `add_ref` to ensure that the invariant of `AddRef` being called before `InterfacePtr::new` is constructed is upheld.  