### PR TITLE
Allow users to implement five five interfaces instead of three

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,12 @@ macro_rules! vtable {
             $crate::offset::$offset,
         >();
     };
+    ($class:ident: $interface:ident, 4usize) => {
+        $crate::vtable!($class: $interface, Four)
+    };
+    ($class:ident: $interface:ident, 3usize) => {
+        $crate::vtable!($class: $interface, Three)
+    };
     ($class:ident: $interface:ident, 2usize) => {
         $crate::vtable!($class: $interface, Two)
     };

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -14,4 +14,4 @@ macro_rules! declare_offset {
     };
 }
 
-declare_offset!(Zero => 0, One => 1, Two => 2);
+declare_offset!(Zero => 0, One => 1, Two => 2, Three => 3, Four => 4);


### PR DESCRIPTION
I did not know how else to fix this, so user can have any amount of implemented interfaces, so I atleast raised it to five.

Fixes #134 