### PR TITLE
Allocated Classes

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -10,30 +10,23 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  build:
+  test:
     runs-on: windows-latest
+    strategy: 
+      matrix: 
+        rust: [1.41.1, stable]
     steps:
     - uses: actions/checkout@v2
-
-    - name: check
-      run: cargo check --all --bins --examples
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        profile: minimal
+        override: true
+        components: rustfmt
 
     - name: tests
       run: cargo test --all 
 
     - name: fmt
       run: cargo fmt --all -- --check
-
-  min-supported:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: install
-      run: rustup install 1.40.0
-
-    - name: check
-      run: cargo +1.40.0 check --all --bins --examples
-
-    - name: tests
-      run: cargo +1.40.0 test --all 
+      if: matrix.rust == 'stable'

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -8,6 +8,7 @@ use interface::{Food, IAnimal, ICat, IDomesticAnimal, IExample, CLSID_CAT_CLASS}
 fn main() {
     init_apartment(ApartmentType::SingleThreaded)
         .unwrap_or_else(|hr| panic!("Failed to initialize COM Library{:x}", hr));
+    println!("Initialized apartment");
 
     let factory = get_class_object::<IClassFactory>(&CLSID_CAT_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get cat class object 0x{:x}", hr));

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     // Call some functions on the `IAnimal` interface
     let food = Food { deliciousness: 10 };
     unsafe { animal.eat(&food) };
-    assert!(unsafe { animal.happiness() } == 20);
+    assert!(unsafe { animal.happiness() } == 10);
 
     // Get a handle to new interface `IDomesticAnimal` which is actually implemented
     // in a different VTable from `IAnimal`

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -40,11 +40,14 @@ fn main() {
         .expect("Failed to get IDomesticAnimal");
     println!("Got IDomesticAnimal");
 
-    // Get a handle to an `ICat` and call a method on that interface
+    // Safely query across interface hierarchies
+    // Get a handle to an `ICat` from an `IDomesticAnimal` even though they
+    // belong to different interface hierarchies and have different vtables
     let new_cat = domestic_animal
         .get_interface::<ICat>()
         .expect("Failed to get ICat");
     println!("Got ICat");
+    // Call a method on the interface `ICat` interface
     unsafe { new_cat.ignore_humans() };
 
     // Get another handle to a `IDomesticAnimal` and call a method on it

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -6,57 +6,70 @@ use com::{
 use interface::{Food, IAnimal, ICat, IDomesticAnimal, IExample, CLSID_CAT_CLASS};
 
 fn main() {
+    // Initialize the COM apartment
     init_apartment(ApartmentType::SingleThreaded)
         .unwrap_or_else(|hr| panic!("Failed to initialize COM Library{:x}", hr));
     println!("Initialized apartment");
 
+    // Get a `BritishShortHairCat` class factory
     let factory = get_class_object::<IClassFactory>(&CLSID_CAT_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get cat class object 0x{:x}", hr));
     println!("Got cat class object");
 
+    // Get an instance of a `BritishShortHairCat` as the `IUnknown` interface
     let unknown = factory
         .get_instance::<IUnknown>()
         .expect("Failed to get IUnknown");
     println!("Got IUnknown");
 
+    // Now get a handle to the `IAnimal` interface
     let animal = unknown
         .get_interface::<IAnimal>()
         .expect("Failed to get IAnimal");
     println!("Got IAnimal");
 
+    // Call some functions on the `IAnimal` interface
     let food = Food { deliciousness: 10 };
     unsafe { animal.eat(&food) };
     assert!(unsafe { animal.happiness() } == 20);
 
-    // Test cross-vtable interface queries for both directions.
+    // Get a handle to new interface `IDomesticAnimal` which is actually implemented
+    // in a different VTable from `IAnimal`
     let domestic_animal = animal
         .get_interface::<IDomesticAnimal>()
         .expect("Failed to get IDomesticAnimal");
     println!("Got IDomesticAnimal");
 
-    unsafe { domestic_animal.train() };
-
+    // Get a handle to an `ICat` and call a method on that interface
     let new_cat = domestic_animal
         .get_interface::<ICat>()
         .expect("Failed to get ICat");
     println!("Got ICat");
     unsafe { new_cat.ignore_humans() };
 
-    // Test querying within second vtable.
+    // Get another handle to a `IDomesticAnimal` and call a method on it
     let domestic_animal_two = domestic_animal
         .get_interface::<IDomesticAnimal>()
         .expect("Failed to get second IDomesticAnimal");
     println!("Got IDomesticAnimal");
     unsafe { domestic_animal_two.train() };
 
+    // Call a method on a parent interface
+    unsafe { domestic_animal.eat(&food) };
+
+    // Directly cast a child interface into a parent without going through `query_interface`
+    let animal: IAnimal = domestic_animal.into();
+    unsafe { animal.eat(&food) };
+
+    // Get another instance of `BritishShortHairCat` from the factory
     let cat = create_instance::<ICat>(&CLSID_CAT_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get a cat {:x}", hr));
     println!("Got another cat");
-
     unsafe { cat.eat(&food) };
 
     assert!(animal.get_interface::<ICat>().is_some());
     assert!(animal.get_interface::<IUnknown>().is_some());
+    // Ensure that getting an interface that the class doesn't implement returns none
     assert!(animal.get_interface::<IExample>().is_none());
     assert!(animal.get_interface::<IDomesticAnimal>().is_some());
 }

--- a/examples/basic/server/src/british_short_hair_cat.rs
+++ b/examples/basic/server/src/british_short_hair_cat.rs
@@ -38,9 +38,3 @@ class! {
         }
     }
 }
-
-impl Default for BritishShortHairCat {
-    fn default() -> BritishShortHairCat {
-        BritishShortHairCat::new(std::cell::Cell::new(10))
-    }
-}

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -139,6 +139,8 @@ impl Class {
         let query_interface = iunknown.to_query_interface_tokens(interfaces);
         let query = iunknown.to_query_tokens();
         let constructor = super::class_constructor::generate(self);
+        let default_constructor = super::class_constructor::generate_default(self);
+        let unsafe_constructor = super::class_constructor::generate_unsafe(self);
         let interface_drops = interfaces.iter().enumerate().map(|(index, _)| {
             let field_ident = quote::format_ident!("__{}", index);
             quote! {
@@ -152,7 +154,8 @@ impl Class {
             }
         });
 
-        quote!(
+        quote! {
+            use super::*;
             #(#docs)*
             #[repr(C)]
             #vis struct #name {
@@ -162,6 +165,8 @@ impl Class {
             }
             impl #name {
                 #constructor
+                #default_constructor
+                #unsafe_constructor
                 #(#methods)*
                 #add_ref
                 #release
@@ -181,7 +186,7 @@ impl Class {
                     }
                 }
             }
-        )
+        }
     }
 
     pub fn to_class_trait_impl_tokens(&self) -> TokenStream {

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -127,9 +127,9 @@ impl Class {
         let docs = &self.docs;
         let methods = self.methods.values().flat_map(|ms| ms);
 
-        let iunknown = super::iunknown_impl::IUnknown::new(name.clone());
+        let iunknown = super::iunknown_impl::IUnknown::new();
         let add_ref = iunknown.to_add_ref_tokens();
-        let release = iunknown.to_release_tokens(interfaces);
+        let release = iunknown.to_release_tokens();
         let query_interface = iunknown.to_query_interface_tokens(interfaces);
         let constructor = super::class_constructor::generate(self);
 
@@ -317,8 +317,7 @@ impl Interface {
     }
 
     fn iunknown_tokens(class: &Class, offset: usize) -> TokenStream {
-        let name = &class.name;
-        let iunknown = super::iunknown_impl::IUnknownAbi::new(name.clone(), offset);
+        let iunknown = super::iunknown_impl::IUnknownAbi::new(class.name.clone(), offset);
         let add_ref = iunknown.to_add_ref_tokens();
         let release = iunknown.to_release_tokens();
         let query_interface = iunknown.to_query_interface_tokens();

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -309,7 +309,7 @@ impl Interface {
             let method = quote! {
                 unsafe extern "stdcall" fn #name(this: ::std::ptr::NonNull<::std::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
                     let this = this.as_ptr().sub(#offset);
-                    let this = ::std::mem::ManuallyDrop::new(::std::pin::Pin::new(::std::boxed::Box::from_raw(this as *mut _ as *mut #class_name)));
+                    let this = ::std::mem::ManuallyDrop::new(::com::production::ClassAllocation::from_raw(this as *mut _ as *mut #class_name));
                     #class_name::#name(&this, #(#args),*)
                 }
             };

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -131,6 +131,7 @@ impl Class {
         let add_ref = iunknown.to_add_ref_tokens();
         let release = iunknown.to_release_tokens();
         let query_interface = iunknown.to_query_interface_tokens(interfaces);
+        let query = iunknown.to_query_tokens();
         let constructor = super::class_constructor::generate(self);
 
         quote!(
@@ -147,6 +148,7 @@ impl Class {
                 #add_ref
                 #release
                 #query_interface
+                #query
             }
         )
     }

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -313,7 +313,7 @@ impl Interface {
             let method = quote! {
                 unsafe extern "stdcall" fn #name(this: ::std::ptr::NonNull<::std::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
                     let this = this.as_ptr().sub(#offset);
-                    let this = ::std::mem::ManuallyDrop::new(::std::boxed::Box::from_raw(this as *mut _ as *mut #class_name));
+                    let this = ::std::mem::ManuallyDrop::new(::std::pin::Pin::new(::std::boxed::Box::from_raw(this as *mut _ as *mut #class_name)));
                     #class_name::#name(&this, #(#args),*)
                 }
             };

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -138,7 +138,6 @@ impl Class {
         let query_interface = iunknown.to_query_interface_tokens(interfaces);
         let query = iunknown.to_query_tokens();
         let constructor = super::class_constructor::generate(self);
-        let unsafe_constructor = super::class_constructor::generate_unsafe(self);
         let interface_drops = interfaces.iter().enumerate().map(|(index, _)| {
             let field_ident = quote::format_ident!("__{}", index);
             quote! {
@@ -163,7 +162,6 @@ impl Class {
             }
             impl #name {
                 #constructor
-                #unsafe_constructor
                 #(#methods)*
                 #add_ref
                 #release

--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -8,7 +8,12 @@ pub fn generate(class: &Class) -> TokenStream {
     let vis = &class.visibility;
 
     let parameters = &class.fields;
-    let user_fields = class.fields.iter().map(|f| &f.ident);
+    let user_fields = class.fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! {
+            #name: ::std::mem::ManuallyDrop::new(#name)
+        }
+    });
 
     let interface_inits = gen_vpointer_inits(class);
     let ref_count_ident = crate::utils::ref_count_ident();

--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -2,7 +2,7 @@ use super::{class::Interface, Class};
 use proc_macro2::TokenStream;
 use quote::quote;
 
-/// Function used to instantiate the COM fields, such as vpointers for the COM object.
+/// Function used to instantiate the COM class
 pub fn generate(class: &Class) -> TokenStream {
     let name = &class.name;
     let vis = &class.visibility;
@@ -22,19 +22,89 @@ pub fn generate(class: &Class) -> TokenStream {
     let interface_fields = gen_allocate_interface_fields(interfaces);
 
     quote! {
-        #vis fn new(#(#parameters),*) -> #name {
+        /// Allocate the COM class
+        #vis fn allocate<T: ::com::Interface>(#(#parameters),*) -> Option<T> {
             #interface_inits
-
-            #name {
+            let instance = #name {
                 #interface_fields
                 #ref_count_ident: std::cell::Cell::new(1),
                 #(#user_fields),*
-            }
-        }
-
-        #vis fn allocate<T: ::com::Interface>(instance: Self) -> Option<T> {
+            };
             let instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(instance));
             instance.query()
+        }
+    }
+}
+
+/// Function used to instantiate a default version COM class
+pub fn generate_default(class: &Class) -> TokenStream {
+    let name = &class.name;
+    let vis = &class.visibility;
+
+    let user_fields = class.fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! {
+            #name: ::std::mem::ManuallyDrop::new(::std::default::Default::default())
+        }
+    });
+
+    let interface_inits = gen_vpointer_inits(class);
+    let ref_count_ident = crate::utils::ref_count_ident();
+
+    let interfaces = &class.interfaces;
+    let interface_fields = gen_allocate_interface_fields(interfaces);
+
+    quote! {
+        /// Allocate a default version of the COM class casting it to the supplied interface.
+        #vis fn allocate_default<T: ::com::Interface>() -> Option<T> {
+            #interface_inits
+            let instance = #name {
+                #interface_fields
+                #ref_count_ident: std::cell::Cell::new(1),
+                #(#user_fields),*
+            };
+            let instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(instance));
+            instance.query()
+        }
+    }
+}
+
+/// Function used to instantiate a class using a raw IID pointer
+pub fn generate_unsafe(class: &Class) -> TokenStream {
+    let name = &class.name;
+    let vis = &class.visibility;
+
+    let user_fields = class.fields.iter().map(|f| {
+        let name = &f.ident;
+        quote! {
+            #name: ::std::mem::ManuallyDrop::new(::std::default::Default::default())
+        }
+    });
+
+    let interface_inits = gen_vpointer_inits(class);
+    let ref_count_ident = crate::utils::ref_count_ident();
+
+    let interfaces = &class.interfaces;
+    let interface_fields = gen_allocate_interface_fields(interfaces);
+
+    quote! {
+        /// Allocate the COM class from a raw IID writing the interface to `interface` pointer
+        ///
+        /// # Safety
+        /// This function is unsafe because the pointers are not guaranteed to be valid. Enure
+        /// that the pointers are non-null and pointing to valid data.
+        #vis unsafe fn allocate_to_interface(
+            iid: *const ::com::sys::IID,
+            interface: *mut *mut ::std::ffi::c_void,
+        ) -> ::com::sys::HRESULT {
+            #interface_inits
+            let instance = #name {
+                #interface_fields
+                #ref_count_ident: std::cell::Cell::new(1),
+                #(#user_fields),*
+            };
+            let instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(instance));
+            instance.query_interface(iid, interface)
         }
     }
 }

--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -27,55 +27,14 @@ pub fn generate(class: &Class) -> TokenStream {
         /// This allocates the class on the heap and pins it. This is because COM classes
         /// must have a stable location in memory. Once a COM class is instantiated somewhere
         /// it must stay there.
-        #vis fn allocate<T: ::com::Interface>(#(#parameters),*) -> Option<T> {
+        #vis fn allocate(#(#parameters),*) -> ::std::pin::Pin<::std::boxed::Box<Self>> {
             #interface_inits
             let instance = #name {
                 #interface_fields
                 #ref_count_ident: std::cell::Cell::new(1),
                 #(#user_fields),*
             };
-            let instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(instance));
-            instance.query()
-        }
-    }
-}
-
-/// Function used to instantiate a class using a raw IID pointer
-pub fn generate_unsafe(class: &Class) -> TokenStream {
-    let name = &class.name;
-    let vis = &class.visibility;
-
-    let user_fields = class.fields.iter().map(|f| {
-        let name = &f.ident;
-        quote! {
-            #name: ::std::mem::ManuallyDrop::new(::std::default::Default::default())
-        }
-    });
-
-    let interface_inits = gen_vpointer_inits(class);
-    let ref_count_ident = crate::utils::ref_count_ident();
-
-    let interfaces = &class.interfaces;
-    let interface_fields = gen_allocate_interface_fields(interfaces);
-
-    quote! {
-        /// Allocate the COM class from a raw IID writing the interface to `interface` pointer
-        ///
-        /// # Safety
-        /// This function is unsafe because the pointers are not guaranteed to be valid. Enure
-        /// that the pointers are non-null and pointing to valid data.
-        #vis unsafe fn allocate_to_interface(
-            iid: *const ::com::sys::IID,
-            interface: *mut *mut ::std::ffi::c_void,
-        ) -> ::com::sys::HRESULT {
-            #interface_inits
-            let instance = #name {
-                #interface_fields
-                #ref_count_ident: std::cell::Cell::new(1),
-                #(#user_fields),*
-            };
-            let instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(instance));
-            instance.query_interface(iid, interface)
+            ::std::boxed::Box::pin(instance)
         }
     }
 }

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -9,6 +9,10 @@ pub fn generate(class: &Class) -> TokenStream {
 
     let class_factory_ident = crate::utils::class_factory_ident(&class.name);
     let class_name = &class.name;
+    let user_fields = class.fields.iter().map(|f| {
+        let ty = &f.ty;
+        quote! { <#ty as ::std::default::Default>::default() }
+    });
     quote! {
         ::com::class! {
             #[no_class_factory]
@@ -26,7 +30,8 @@ pub fn generate(class: &Class) -> TokenStream {
                         return ::com::sys::CLASS_E_NOAGGREGATION;
                     }
 
-                    #class_name::allocate_to_interface(riid, ppv)
+                    let instance = #class_name::allocate(#(#user_fields)*,);
+                    instance.query_interface(riid, ppv)
                 }
 
                 unsafe fn LockServer(&self, _increment: com::sys::BOOL) -> com::sys::HRESULT {

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -19,12 +19,12 @@ pub fn generate(class: &Class) -> TokenStream {
                     riid: *const com::sys::IID,
                     ppv: *mut *mut std::ffi::c_void,
                 ) -> com::sys::HRESULT {
+                    assert!(!riid.is_null(), "iid passed to CreateInstance was null");
                     if aggr != std::ptr::null_mut() {
                         return com::sys::CLASS_E_NOAGGREGATION;
                     }
 
-                    let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<#class_name as ::std::default::Default>::default()));
-                    instance.query_interface(riid, ppv)
+                    #class_name::allocate_to_interface(riid, ppv)
                 }
 
                 unsafe fn LockServer(&self, _increment: com::sys::BOOL) -> com::sys::HRESULT {

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -3,32 +3,34 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 pub fn generate(class: &Class) -> TokenStream {
-    if class.class_factory {
+    if !class.has_class_factory {
         return TokenStream::new();
     }
+
     let class_factory_ident = crate::utils::class_factory_ident(&class.name);
     let class_name = &class.name;
     quote! {
         ::com::class! {
-            pub factory #class_factory_ident: ::com::interfaces::IClassFactory {}
+            #[no_class_factory]
+            pub class #class_factory_ident: ::com::interfaces::IClassFactory {}
 
             impl ::com::interfaces::IClassFactory for #class_factory_ident {
                 unsafe fn CreateInstance(
                     &self,
-                    aggr: *mut std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
-                    riid: *const com::sys::IID,
-                    ppv: *mut *mut std::ffi::c_void,
-                ) -> com::sys::HRESULT {
+                    aggr: *mut ::std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
+                    riid: *const ::com::sys::IID,
+                    ppv: *mut *mut ::std::ffi::c_void,
+                ) -> ::com::sys::HRESULT {
                     assert!(!riid.is_null(), "iid passed to CreateInstance was null");
-                    if aggr != std::ptr::null_mut() {
-                        return com::sys::CLASS_E_NOAGGREGATION;
+                    if aggr != ::std::ptr::null_mut() {
+                        return ::com::sys::CLASS_E_NOAGGREGATION;
                     }
 
                     #class_name::allocate_to_interface(riid, ppv)
                 }
 
                 unsafe fn LockServer(&self, _increment: com::sys::BOOL) -> com::sys::HRESULT {
-                    com::sys::S_OK
+                    ::com::sys::S_OK
                 }
             }
         }

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -24,11 +24,7 @@ pub fn generate(class: &Class) -> TokenStream {
                     }
 
                     let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<#class_name as ::std::default::Default>::default()));
-                    instance.add_ref();
-                    let hr = instance.query_interface(riid, ppv);
-                    instance.release();
-
-                    hr
+                    instance.query_interface(riid, ppv)
                 }
 
                 unsafe fn LockServer(&self, _increment: com::sys::BOOL) -> com::sys::HRESULT {

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -23,12 +23,11 @@ pub fn generate(class: &Class) -> TokenStream {
                         return com::sys::CLASS_E_NOAGGREGATION;
                     }
 
-                    let mut instance = ::std::boxed::Box::new(<#class_name as ::std::default::Default>::default());
+                    let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<#class_name as ::std::default::Default>::default()));
                     instance.add_ref();
                     let hr = instance.query_interface(riid, ppv);
                     instance.release();
 
-                    core::mem::forget(instance);
                     hr
                 }
 

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -48,12 +48,10 @@ impl Interface {
         let deref = self.deref_impl();
         let drop = self.drop_impl();
         let clone = self.clone_impl();
-        let safe_query = self.safe_query();
 
         quote! {
             impl #interface_name {
                 #(#methods)*
-                #safe_query
             }
             #deref
             #drop
@@ -103,23 +101,6 @@ impl Interface {
                         inner: self.inner
                     }
                 }
-            }
-        }
-    }
-
-    fn safe_query(&self) -> TokenStream {
-        if self.is_iunknown() {
-            return TokenStream::new();
-        }
-        let vis = &self.visibility;
-        quote! {
-            /// A safe version of `QueryInterface`.
-            ///
-            /// If the backing class implements the interface `I` then a `Some`
-            /// containing an `ComPtr` pointing to that interface will be returned
-            /// otherwise `None` will be returned.
-            #vis fn get_interface<I: ::com::Interface>(&self) -> Option<I> {
-                <Self as ::com::Interface>::as_iunknown(self).get_interface()
             }
         }
     }

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -84,9 +84,7 @@ impl Interface {
         quote! {
             impl Drop for #name {
                 fn drop(&mut self) {
-                    unsafe {
-                        <Self as ::com::Interface>::as_iunknown(self).release();
-                    }
+                    unsafe { <Self as ::com::Interface>::as_iunknown(self).release(); }
                 }
             }
         }

--- a/src/production.rs
+++ b/src/production.rs
@@ -3,7 +3,4 @@ mod class;
 pub mod registration;
 
 #[doc(inline)]
-pub use class::Class;
-
-#[doc(inline)]
-pub use class::ClassAllocation;
+pub use class::{Class, ClassAllocation};

--- a/src/production.rs
+++ b/src/production.rs
@@ -4,3 +4,6 @@ pub mod registration;
 
 #[doc(inline)]
 pub use class::Class;
+
+#[doc(inline)]
+pub use class::ClassAllocation;

--- a/src/production/class.rs
+++ b/src/production/class.rs
@@ -38,7 +38,8 @@ impl<T: Class> ClassAllocation<T> {
     /// Create an allocated class from a raw pointer
     ///
     /// # Safety
-    /// Must be a valid pointer to an allocated COM class.
+    /// Must be a valid, owned pointer to an allocated COM class. This returns an owned `ClassAllocation`
+    /// which will drop the wrapped COM class when it is dropped.
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         let inner = std::mem::ManuallyDrop::new(Box::from_raw(raw).into());
         Self { inner }
@@ -61,5 +62,14 @@ impl<T: Class> Drop for ClassAllocation<T> {
                 std::mem::ManuallyDrop::drop(&mut self.inner);
             }
         }
+    }
+}
+
+impl<T: Class> std::fmt::Debug for ClassAllocation<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ptr = self.inner.as_ref().get_ref() as *const T;
+        f.debug_struct("ClassAllocation")
+            .field("ptr", &ptr)
+            .finish()
     }
 }

--- a/src/production/class.rs
+++ b/src/production/class.rs
@@ -9,4 +9,57 @@
 pub unsafe trait Class {
     /// The factory object associated with this class
     type Factory;
+
+    /// Decrement the current reference count and return the new count
+    fn dec_ref_count(&self) -> u32;
+}
+
+/// An allocated COM class
+///
+/// The class must be heap allocated and not be moved in memory.
+/// This wrapper decrements the inner class ref count when dropped
+/// and frees the heap allocation as well as the class itself when
+/// that ref count is 0.
+#[repr(transparent)]
+pub struct ClassAllocation<T: Class> {
+    inner: std::mem::ManuallyDrop<std::pin::Pin<Box<T>>>,
+}
+
+impl<T: Class> ClassAllocation<T> {
+    /// Create a new class allocation
+    ///
+    /// This is not normally used by users of the COM crate but by the code generator
+    pub fn new(inner: std::pin::Pin<Box<T>>) -> Self {
+        Self {
+            inner: std::mem::ManuallyDrop::new(inner),
+        }
+    }
+
+    /// Create an allocated class from a raw pointer
+    ///
+    /// # Safety
+    /// Must be a valid pointer to an allocated COM class.
+    pub unsafe fn from_raw(raw: *mut T) -> Self {
+        let inner = std::mem::ManuallyDrop::new(Box::from_raw(raw).into());
+        Self { inner }
+    }
+}
+
+impl<T: Class> std::ops::Deref for ClassAllocation<T> {
+    type Target = std::pin::Pin<Box<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T: Class> Drop for ClassAllocation<T> {
+    fn drop(&mut self) {
+        if self.inner.dec_ref_count() == 0 {
+            // SAFETY: This is safe because the inner value is not accessible by anyone else
+            unsafe {
+                std::mem::ManuallyDrop::drop(&mut self.inner);
+            }
+        }
+    }
 }

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -207,16 +207,10 @@ macro_rules! inproc_dll_module {
             let class_id = unsafe { &*class_id };
             if class_id == &$class_id_one {
                 let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<$class_type_one as ::com::production::Class>::Factory::new()));
-                instance.add_ref();
-                let hr = instance.query_interface(iid, result);
-                instance.release();
-                hr
+                instance.query_interface(iid, result)
             } $(else if class_id == &$class_id {
                 let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<$class_type_one as ::com::production::Class>::Factory::new()));
-                instance.add_ref();
-                let hr = instance.query_interface(iid, result);
-                instance.release();
-                hr
+                instance.query_interface(iid, result)
             })* else {
                 ::com::sys::CLASS_E_CLASSNOTAVAILABLE
             }

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -206,11 +206,9 @@ macro_rules! inproc_dll_module {
 
             let class_id = unsafe { &*class_id };
             if class_id == &$class_id_one {
-                let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<$class_type_one as ::com::production::Class>::Factory::new()));
-                instance.query_interface(iid, result)
+                <$class_type_one as ::com::production::Class>::Factory::allocate_to_interface(&*iid, result)
             } $(else if class_id == &$class_id {
-                let mut instance = ::std::mem::ManuallyDrop::new(::std::boxed::Box::pin(<$class_type_one as ::com::production::Class>::Factory::new()));
-                instance.query_interface(iid, result)
+                <$class_type_one as ::com::production::Class>::Factory::allocate_to_interface(&*iid, result)
             })* else {
                 ::com::sys::CLASS_E_CLASSNOTAVAILABLE
             }

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -209,9 +209,11 @@ macro_rules! inproc_dll_module {
 
             let class_id = unsafe { &*class_id };
             if class_id == &$class_id_one {
-                <$class_type_one as ::com::production::Class>::Factory::allocate_to_interface(&*iid, result)
+                let instance = <$class_type_one as ::com::production::Class>::Factory::allocate();
+                instance.query_interface(&*iid, result)
             } $(else if class_id == &$class_id {
-                <$class_type_one as ::com::production::Class>::Factory::allocate_to_interface(&*iid, result)
+                let instance = <$class_type_one as ::com::production::Class>::Factory::allocate();
+                instance.query_interface(&*iid, result)
             })* else {
                 ::com::sys::CLASS_E_CLASSNOTAVAILABLE
             }


### PR DESCRIPTION
Fixes #161 

This (hopefully) fixes the issues in #161 which are:
* **COM interface methods must be called on objects that are heap allocated**: We don't force the user to conform to this for regular methods because it's possible to safely use methods with `&self`. However, the IUnknown methods assume that self is heap allocated and won't move. We model this by taking self as `self: &Pin<Box<Self>>`. This makes it not possible to call IUnknown methods on a stack allocated object. If users must assume that their code is heap allocated they can declare their methods with the same signature as the IUnknown methods but if the assumption is not needed, they can just use `&self`. 
* **There is no safe query_interface**: classes now come with a safe query interface method called `query`. This may only be used when the type is heap allocated and pinned. 
* **It is confusing how to properly instantiate a class**:  Classes now come with an `alloc` associated function which heap allocates the class, pins it, and queries the class for a given interface. 
* **Memory management of the class is potentially wrong**: classes now properly use their ref count to manage memory. The ref count starts at 1 and is incremented and decremented with `add_ref` and `release` respectively. On drop, the ref count is also decremented. When the count is 0, the class's contents are dropped. This should only happen inside of the `release` thunk or if the class is manually allocated by the user and never shared.  