### PR TITLE
Switch casing for raw COM methods to CamelCase and add some docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ let mut cat = create_instance::<IAnimal>(&CLSID_CAT_CLASS).expect("Failed to get
 // All IAnimal methods will be available.
 // Because we are crossing an FFI boundary, all COM interfaces are marked as unsafe.
 // It is the job of the programmer to ensure that invariants beyond what the COM library guarantees are upheld.
-// See the unsafe documentation for more info.
 unsafe { cat.Eat(); }
 ```
+
+For more information on usage and safety, take a look at the [docs](./docs).
 
 ### Producing a COM component
 
@@ -107,6 +108,8 @@ com::class! {
     }
 }
 ```
+
+For more information on usage and safety, take a look at the [docs](./docs).
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -27,18 +27,18 @@ To both consume or produce a COM component through an interface, you will first 
 com::interfaces! {
     #[uuid("00000000-0000-0000-C000-000000000046")]
     pub unsafe interface IUnknown {
-        fn query_interface(
+        fn QueryInterface(
             &self,
             riid: *const IID,
             ppv: *mut *mut c_void
         ) -> HRESULT;
-        fn add_ref(&self) -> u32;
-        fn release(&self) -> u32;
+        fn AddRef(&self) -> u32;
+        fn Release(&self) -> u32;
     }
 
     #[uuid("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
     pub unsafe interface IAnimal: IUnknown {
-        fn eat(&self) -> HRESULT;
+        fn Eat(&self) -> HRESULT;
     }
 }
 ```
@@ -58,14 +58,14 @@ init_runtime().expect("Failed to initialize COM Library");
 // Get a COM instance's interface pointer, by specifying
 // - The CLSID of the COM component
 // - The interface of the COM component that you want
-// create_instance returns a ComRc<dyn IAnimal> in this case.
+// create_instance returns an IAnimal interface in this case.
 let mut cat = create_instance::<IAnimal>(&CLSID_CAT_CLASS).expect("Failed to get a cat");
 
 // All IAnimal methods will be available.
 // Because we are crossing an FFI boundary, all COM interfaces are marked as unsafe.
 // It is the job of the programmer to ensure that invariants beyond what the COM library guarantees are upheld.
 // See the unsafe documentation for more info.
-unsafe { cat.eat(); }
+unsafe { cat.Eat(); }
 ```
 
 ### Producing a COM component
@@ -86,35 +86,24 @@ com::class! {
     
     
     impl IDomesticAnimal for BritishShortHairCat {
-        fn train(&self) -> HRESULT {
+        fn Train(&self) -> HRESULT {
             println!("Training...");
             NOERROR
         }
     }
     
     impl ICat for BritishShortHairCat {
-        fn ignore_humans(&self) -> HRESULT {
+        fn IgnoreHumans(&self) -> HRESULT {
             println!("Ignoring Humans...");
             NOERROR
         }
     }
     
     impl IAnimal for BritishShortHairCat {
-        fn eat(&self) -> HRESULT {
+        fn Eat(&self) -> HRESULT {
             println!("Eating...");
             NOERROR
         }
-    }
-}
-```
-
-3. You must implement the `Default` trait from the standard library which is used by a class's class factory for instantiating the class.
-Note: that a `new` associated function is defined for you which takes all the user defined values of the class.
-```rust
-impl Default for BritishShortHairCat {
-    fn default() -> BritishShortHairCat {
-        /// `BritishShortHairCat::new` was defined for us and takes the `num_owners` as its only argument
-        BritishShortHairCat::new(20)
     }
 }
 ```

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -1,0 +1,88 @@
+# Basic Usage
+
+The following is a basic annotated example of how to use this crate.
+
+## Interfaces
+
+Let's assume that you want to interact with a COM API from Rust. This COM API already exists and is documented through the use of an IDL declaration.
+
+```
+typedef struct Data
+{
+    float x;
+    float y;
+} Data;
+
+interface IMyInterface : IUnknown
+{
+    HRESULT MyMethod(
+        [in] const Data *my_data,
+        [in] long n,
+        [out] IMyOtherInterface **other
+    );
+}
+
+interface IMyOtherInterface : IMyInterface
+{
+    HRESULT MyOtherMethod();
+}
+```
+
+We must translate this IDL direclty into Rust code using `com::interfaces!` macro.
+
+Take note that each method and argument must be in the same exact order and must have the same in-memory properties as the types declared in the IDL.
+
+```rust 
+/// The Data struct must match the in-memory layout exactly. We therefore use `#[repr(C)]`.
+#[repr(C)]
+struct Data {
+    x: f32, // IDL's float type and Rust's f32 have the same in-memory layout
+    y: f32, // Note, the order of the fields here matters not necessarily their names
+}
+
+com::interfaces! {
+    unsafe interface IMyInterface: IUnknown {
+        fn MyMethod(
+            my_data: &Data,
+            n: i64, // C's long is equivalent to Rust's i64
+            // This is the largest translation difference.
+            // com-rs'rs interface types are equivalent to a non-null `IInterface *const` 
+            // In this case, since `other` is an [out] arg, we want to be able to pass a pointer to
+            // NULL which can then be set to the interface pointer. We model this by wrapping
+            // the interface type in an `Option`. In other words `Option<IMyOtherInterface>` is equivalent
+            // to a nullable `IIterface *const` (not the single pointer). Because we want `MyMethod` to 
+            // write to `other`, we pass a `&mut`.
+            other: &mut Option<IMyOtherInterface>
+        ) -> com::sys::HRESULT;
+    }
+
+    unsafe interface IMyOtherInterface: IMyInterface {
+        fn MyOtherMethod() -> com::sys::HRESULT;
+    }
+}
+```
+
+Using this interface is pretty straight forward. Let's assume the library you're using has a function called `getInterface` which returns a `IMyInterface *const`. This would have the following signature in Rust.
+
+```rust
+extern {
+    // Note that com-rs interface types are equivalent to the C `IInterface *const`.
+    fn getInterface() -> IMyInterface
+}
+```
+
+To use this interface you can do the following:
+
+```rust
+let my_interface = unsafe { getInterface() };
+let data = Data { x: 10.0, y: 4.0 };
+let mut my_other_interface = None;
+unsafe { my_interface.MyMethod(&data, 100, &mut my_other_interface) };
+unsafe { my_other_interface.MyOtherMethod() };
+```
+
+Of course, you may want to use Windows APIs for getting a registered COM component. Safe wrappers to such APIs can be found in `com::runtime`.
+
+## Classes
+
+TODO: document how to use COM classes

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -16,8 +16,8 @@ typedef struct Data
 interface IMyInterface : IUnknown
 {
     HRESULT MyMethod(
-        [in] const Data *my_data,
-        [in] long n,
+        const Data *my_data,
+        INT32 n,
         [out] IMyOtherInterface **other
     );
 }
@@ -44,7 +44,7 @@ com::interfaces! {
     unsafe interface IMyInterface: IUnknown {
         fn MyMethod(
             my_data: &Data,
-            n: i64, // C's long is equivalent to Rust's i64
+            n: i32, // INT32 is equivalent to Rust's i32
             // This is the largest translation difference.
             // com-rs'rs interface types are equivalent to a non-null `IInterface *const` 
             // In this case, since `other` is an [out] arg, we want to be able to pass a pointer to
@@ -78,7 +78,7 @@ let my_interface = unsafe { getInterface() };
 let data = Data { x: 10.0, y: 4.0 };
 let mut my_other_interface = None;
 unsafe { my_interface.MyMethod(&data, 100, &mut my_other_interface) };
-unsafe { my_other_interface.MyOtherMethod() };
+unsafe { my_other_interface.unwrap().MyOtherMethod() };
 ```
 
 Of course, you may want to use Windows APIs for getting a registered COM component. Safe wrappers to such APIs can be found in `com::runtime`.

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -27,7 +27,7 @@ interface to be safe.
 com::interfaces! {
     #[uuid("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
     pub unsafe interface IAnimal: IUnknown {
-        fn eat(&self) -> HRESULT;
+        fn Eat(&self) -> HRESULT;
     }
 }
 ```
@@ -51,7 +51,7 @@ impl IAnimal {
     // in the interface is still valid.
     // This is likely to be the case as interface automatically keeps 
     // track of its reference count.
-    pub unsafe fn eat(&self) -> HRESULT {
+    pub unsafe fn Eat(&self) -> HRESULT {
         let interface_ptr = <Self as com::AbiTransferable>::get_abi(self);
         (interface_ptr.as_ref().as_ref().Eat)(interface_ptr)
     }
@@ -71,7 +71,7 @@ impl std::ops::Deref for IAnimal {
 impl Drop for IAnimal {
     fn drop(&mut self) {
         unsafe {
-            <Self as com::Interface>::as_iunknown(self).release();
+            <Self as com::Interface>::as_iunknown(self).Release();
         }
     }
 }
@@ -80,7 +80,7 @@ impl Drop for IAnimal {
 impl ::std::clone::Clone for IAnimal {
     fn clone(&self) -> Self {
         unsafe {
-            <Self as com::Interface>::as_iunknown(self).add_ref();
+            <Self as com::Interface>::as_iunknown(self).AddRef();
         }
         Self { inner: self.inner }
     }

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -1,7 +1,6 @@
 # Safety
 
-COM specifies very little in the way of memory safety of COM based APIs. It is left up to
- the programmer to verify APIs and to make safe wrappers for them.
+COM specifies very little in the way of memory safety of COM based APIs. It is left up to the programmer to verify APIs and to make safe wrappers for them.
 
 ## The `unsafe` Keyword
 
@@ -9,19 +8,13 @@ It is a requirement for all usages of COM methods be marked as `unsafe`. This is
 
 ## `&self`, `&mut self`, and `self`
 
-All methods of a COM interface are required to take an unexclusive reference to self 
-(`&self`). This reflects the reality that COM interfaces do not have exclusive access to 
-the underlying class,and it does not take ownership (i.e., it is not responsible for the 
-destruction) of the underlying class. As such if you're implementing a COM server, you 
-will most likely need to use [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) 
-if you would like to mutate state in method calls.
+All methods of a COM interface are required to take an unexclusive reference to self (`&self`). This reflects the reality that COM interfaces do not have exclusive access to the underlying class,and it does not take ownership (i.e., it is not responsible for the destruction) of the underlying class. As such if you're implementing a COM server, you will most likely need to use [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html) if you would like to mutate state in method calls.
 
 ## Example
 
-In order to understand the safety properties of a COM interface in Rust, it's easiest to 
-look at an example. We'll try to declare a minimum COM interface. This interface will 
-seemingly do very little, but we'll explore what the programmer must ensure for this
-interface to be safe.
+It may be helpful to look at an example of a COM interface and what code gets generated to better understand its safety properties. 
+
+We'll try to declare a minimum COM interface. This interface will seemingly do very little, but we'll explore what the programmer must ensure for this interface to be safe.
 
 ```rust
 com::interfaces! {
@@ -32,8 +25,7 @@ com::interfaces! {
 }
 ```
 
-`IAnimal` is a minimal COM interface that only adds one method on top of the three methods 
-defined by `IUnknown`.
+`IAnimal` is a minimal COM interface that only adds one method on top of the three methods defined by `IUnknown`.
 
 This interface will expand to the following code.
 
@@ -57,12 +49,12 @@ impl IAnimal {
     }
 }
 
-// All interfaces dereference to their parent interface
+// All interfaces dereference to their parent interface.
 impl std::ops::Deref for IAnimal {
     type Target = <IAnimal as com::Interface>::Super;
     fn deref(&self) -> &Self::Target {
         // This is safe because a valid reference to the child interface is exactly 
-        // equal to a valid reference to its parent interface
+        // equal to a valid reference to its parent interface.
         unsafe { std::mem::transmute(self) }
     }
 }
@@ -70,13 +62,15 @@ impl std::ops::Deref for IAnimal {
 // On drop the interface will call the IUknown::Release method
 impl Drop for IAnimal {
     fn drop(&mut self) {
+        // This is safe because we are calling `Release` when the interface handle is no
+        // longer being used.
         unsafe {
             <Self as com::Interface>::as_iunknown(self).Release();
         }
     }
 }
 
-// Cloning the interface increases its reference count
+// Cloning the interface increases its reference count.
 impl ::std::clone::Clone for IAnimal {
     fn clone(&self) -> Self {
         unsafe {
@@ -89,6 +83,8 @@ impl ::std::clone::Clone for IAnimal {
 // The interfaces vtable first contains the parent's vtable and then
 // any methods declared on that interface
 #[allow(non_snake_case)]
+// Notice that this struct is declared `#[repr(C)]` as the order of the COM methods is
+// essential to things working properly
 #[repr(C)]
 pub struct IAnimalVTable {
     pub iunknown_base: <IUnknown as com::Interface>::VTable,
@@ -112,6 +108,8 @@ pub const IID_IANIMAL: com::sys::IID = com::sys::IID {
 /// Conversions to parent interface
 impl std::convert::From<IAnimal> for IUnknown {
     fn from(this: IAnimal) -> Self {
+        // This is safe because child interface handles are exactly equivalent in memory
+        // to their parent interface handles
         unsafe { std::mem::transmute(this) }
     }
 }
@@ -133,3 +131,11 @@ impl<'a> ::std::convert::Into<::com::Param<'a, IUnknown>> for &'a IAnimal {
     }
 }
 ```
+
+## When is it safe to call a COM interface method?
+
+First, a COM interface handle is declared as a transparent wrapper around a `std::ptr::NonNull<std::ptr::NonNull<IMyInterfaceVTable>>`. As long as interface handle was created from properly (e.g., using `com::runtime::get_class_object` to instantiate a COM class object) then the interface handle should behave correctly and should always point to a valid COM object.
+
+The interface handle calls `IUnknown::Release` when it is dropped and `IUnknown::AddRef` when it is cloned. Proper COM class implementations should then ensure that the COM class is only released when no more interface handles exist.
+
+COM methods must only use FFI safe arguments. Sending something without a well specified layout in memory (e.g., a Rust `Vec`) is not safe. Often times COM methods have additional properties that their arguments must meet. It is up to the programmer that the arguments meet these requirements.

--- a/examples/basic/client/src/main.rs
+++ b/examples/basic/client/src/main.rs
@@ -18,25 +18,25 @@ fn main() {
 
     // Get an instance of a `BritishShortHairCat` as the `IUnknown` interface
     let unknown = factory
-        .get_instance::<IUnknown>()
+        .create_instance::<IUnknown>()
         .expect("Failed to get IUnknown");
     println!("Got IUnknown");
 
     // Now get a handle to the `IAnimal` interface
     let animal = unknown
-        .get_interface::<IAnimal>()
+        .query_interface::<IAnimal>()
         .expect("Failed to get IAnimal");
     println!("Got IAnimal");
 
     // Call some functions on the `IAnimal` interface
     let food = Food { deliciousness: 10 };
-    unsafe { animal.eat(&food) };
-    assert!(unsafe { animal.happiness() } == 10);
+    unsafe { animal.Eat(&food) };
+    assert!(unsafe { animal.Happiness() } == 10);
 
     // Get a handle to new interface `IDomesticAnimal` which is actually implemented
     // in a different VTable from `IAnimal`
     let domestic_animal = animal
-        .get_interface::<IDomesticAnimal>()
+        .query_interface::<IDomesticAnimal>()
         .expect("Failed to get IDomesticAnimal");
     println!("Got IDomesticAnimal");
 
@@ -44,35 +44,35 @@ fn main() {
     // Get a handle to an `ICat` from an `IDomesticAnimal` even though they
     // belong to different interface hierarchies and have different vtables
     let new_cat = domestic_animal
-        .get_interface::<ICat>()
+        .query_interface::<ICat>()
         .expect("Failed to get ICat");
     println!("Got ICat");
     // Call a method on the interface `ICat` interface
-    unsafe { new_cat.ignore_humans() };
+    unsafe { new_cat.IgnoreHumans() };
 
     // Get another handle to a `IDomesticAnimal` and call a method on it
     let domestic_animal_two = domestic_animal
-        .get_interface::<IDomesticAnimal>()
+        .query_interface::<IDomesticAnimal>()
         .expect("Failed to get second IDomesticAnimal");
     println!("Got IDomesticAnimal");
-    unsafe { domestic_animal_two.train() };
+    unsafe { domestic_animal_two.Train() };
 
     // Call a method on a parent interface
-    unsafe { domestic_animal.eat(&food) };
+    unsafe { domestic_animal.Eat(&food) };
 
     // Directly cast a child interface into a parent without going through `query_interface`
     let animal: IAnimal = domestic_animal.into();
-    unsafe { animal.eat(&food) };
+    unsafe { animal.Eat(&food) };
 
     // Get another instance of `BritishShortHairCat` from the factory
     let cat = create_instance::<ICat>(&CLSID_CAT_CLASS)
         .unwrap_or_else(|hr| panic!("Failed to get a cat {:x}", hr));
     println!("Got another cat");
-    unsafe { cat.eat(&food) };
+    unsafe { cat.Eat(&food) };
 
-    assert!(animal.get_interface::<ICat>().is_some());
-    assert!(animal.get_interface::<IUnknown>().is_some());
+    assert!(animal.query_interface::<ICat>().is_some());
+    assert!(animal.query_interface::<IUnknown>().is_some());
     // Ensure that getting an interface that the class doesn't implement returns none
-    assert!(animal.get_interface::<IExample>().is_none());
-    assert!(animal.get_interface::<IDomesticAnimal>().is_some());
+    assert!(animal.query_interface::<IExample>().is_none());
+    assert!(animal.query_interface::<IDomesticAnimal>().is_some());
 }

--- a/examples/basic/interface/src/ianimal.rs
+++ b/examples/basic/interface/src/ianimal.rs
@@ -4,7 +4,7 @@ use com::{interfaces, interfaces::iunknown::IUnknown, sys::HRESULT};
 interfaces! {
     #[uuid("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
     pub unsafe interface IAnimal: IUnknown {
-        pub fn eat(&self, food: *const Food) -> HRESULT;
-        pub fn happiness(&self) -> usize;
+        pub fn Eat(&self, food: *const Food) -> HRESULT;
+        pub fn Happiness(&self) -> usize;
     }
 }

--- a/examples/basic/interface/src/icat.rs
+++ b/examples/basic/interface/src/icat.rs
@@ -6,6 +6,6 @@ use crate::IAnimal;
 interfaces! {
     #[uuid("F5353C58-CFD9-4204-8D92-D274C7578B53")]
     pub unsafe interface ICat: IAnimal {
-        pub fn ignore_humans(&self) -> HRESULT;
+        pub fn IgnoreHumans(&self) -> HRESULT;
     }
 }

--- a/examples/basic/interface/src/idomesticanimal.rs
+++ b/examples/basic/interface/src/idomesticanimal.rs
@@ -6,6 +6,6 @@ use crate::IAnimal;
 interfaces! {
     #[uuid("C22425DF-EFB2-4B85-933E-9CF7B23459E8")]
     pub unsafe interface IDomesticAnimal: IAnimal {
-        pub fn train(&self) -> HRESULT;
+        pub fn Train(&self) -> HRESULT;
     }
 }

--- a/examples/basic/server/src/british_short_hair_cat.rs
+++ b/examples/basic/server/src/british_short_hair_cat.rs
@@ -11,29 +11,29 @@ class! {
     }
 
     impl IDomesticAnimal for BritishShortHairCat {
-        fn train(&self) -> HRESULT {
+        fn Train(&self) -> HRESULT {
             println!("Training...");
             NOERROR
         }
     }
 
     impl ICat for BritishShortHairCat {
-        fn ignore_humans(&self) -> HRESULT {
+        fn IgnoreHumans(&self) -> HRESULT {
             println!("Ignoring Humans...");
             NOERROR
         }
     }
 
     impl IAnimal for BritishShortHairCat {
-        fn eat(&self, food: *const Food) -> HRESULT {
+        fn Eat(&self, food: *const Food) -> HRESULT {
             assert!(!food.is_null());
             let food = unsafe { *food };
-            println!("Eating...");
+            println!("Eating food with deliciousness level {}...", food.deliciousness);
             self.happiness.set(self.happiness.get() + food.deliciousness);
             NOERROR
         }
 
-        fn happiness(&self) ->usize {
+        fn Happiness(&self) ->usize {
             self.happiness.get()
         }
     }

--- a/examples/d2d-clock/src/main.rs
+++ b/examples/d2d-clock/src/main.rs
@@ -154,13 +154,13 @@ impl Clock {
     }
 
     fn render(&mut self) {
-        unsafe { self.device_dependent_resources.target.begin_draw() };
+        unsafe { self.device_dependent_resources.target.BeginDraw() };
         self.draw();
         let hr = unsafe {
             self.device_dependent_resources
                 .target
-                .end_draw(std::ptr::null_mut(), std::ptr::null_mut());
-            self.device_dependent_resources.swap_chain.present(1, 0)
+                .EndDraw(std::ptr::null_mut(), std::ptr::null_mut());
+            self.device_dependent_resources.swap_chain.Present(1, 0)
         };
 
         match hr {
@@ -193,10 +193,10 @@ impl Clock {
             HR!(self
                 .device_independent_resources
                 .animation_manager
-                .update(time, std::ptr::null_mut()));
+                .Update(time, std::ptr::null_mut()));
 
             let target = &self.device_dependent_resources.target;
-            target.set_unit_mode(D2D1_UNIT_MODE_PIXELS);
+            target.SetUnitMode(D2D1_UNIT_MODE_PIXELS);
 
             let color_white = D2D1_COLOR_F {
                 r: 1.0,
@@ -204,17 +204,17 @@ impl Clock {
                 b: 1.0,
                 a: 1.0,
             };
-            target.clear(&color_white);
-            target.set_unit_mode(D2D1_UNIT_MODE_DIPS);
+            target.Clear(&color_white);
+            target.SetUnitMode(D2D1_UNIT_MODE_DIPS);
 
             let mut previous = None;
-            target.get_target(&mut previous);
+            target.GetTarget(&mut previous);
             let clock = &self.device_dependent_resources.clock;
-            target.set_target(clock);
-            target.clear(std::ptr::null());
+            target.SetTarget(clock);
+            target.Clear(std::ptr::null());
             self.draw_clock();
             let target = &self.device_dependent_resources.target;
-            target.set_target(previous.unwrap());
+            target.SetTarget(previous.unwrap());
 
             let clock = &self.device_dependent_resources.clock;
 
@@ -224,7 +224,7 @@ impl Clock {
             transform.matrix[2][0] = offset.width;
             transform.matrix[2][1] = offset.height;
 
-            target.set_transform(&transform);
+            target.SetTransform(&transform);
 
             // target.draw_image(
             //     self.shadow.get(),
@@ -235,9 +235,9 @@ impl Clock {
             let mut identity = D2D_MATRIX_3X2_F::default();
             identity.matrix[0][0] = 1.0;
             identity.matrix[1][1] = 1.0;
-            target.set_transform(&identity);
+            target.SetTransform(&identity);
 
-            target.draw_image(
+            target.DrawImage(
                 clock,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -251,7 +251,7 @@ impl Clock {
         let target = &self.device_dependent_resources.target;
         unsafe {
             let mut size = std::mem::zeroed();
-            target.get_size(&mut size);
+            target.GetSize(&mut size);
             let radius = 200.0f32.max(size.width.min(size.height) / 2.0 - 50.0);
             let offset = d2d1::D2D1_SIZE_F {
                 width: 2.0,
@@ -262,8 +262,8 @@ impl Clock {
             translation.matrix[1][1] = 1.0;
             translation.matrix[2][0] = size.width / offset.width;
             translation.matrix[2][1] = size.height / offset.height;
-            target.set_transform(&translation);
-            target.get_transform(&mut translation);
+            target.SetTransform(&translation);
+            target.GetTransform(&mut translation);
 
             let brush = &self.device_dependent_resources.brush;
             let ellipse = D2D1_ELLIPSE {
@@ -272,7 +272,7 @@ impl Clock {
                 radiusY: 50.0,
             };
 
-            target.draw_ellipse(&ellipse, brush, radius / 20.0, None);
+            target.DrawEllipse(&ellipse, brush, radius / 20.0, None);
 
             let mut time = SYSTEMTIME::default();
             GetLocalTime(&mut time);
@@ -285,7 +285,7 @@ impl Clock {
             HR!(self
                 .device_independent_resources
                 .animation_variable
-                .get_value(&mut swing));
+                .GetValue(&mut swing));
 
             if 1.0 > swing {
                 // static secondPrevious: f64 = second_angle;
@@ -308,14 +308,14 @@ impl Clock {
                 &mut rotation,
             );
             let transform = rotation; //* self.orientation * translation;
-            target.set_transform(&transform);
+            target.SetTransform(&transform);
 
             let zero = d2d1::D2D1_POINT_2F { x: 0.0, y: 0.0 };
             let end = d2d1::D2D1_POINT_2F {
                 x: 0.0,
                 y: -(radius * 0.75),
             };
-            target.draw_line(
+            target.DrawLine(
                 zero,
                 end,
                 &self.device_dependent_resources.brush,
@@ -325,7 +325,7 @@ impl Clock {
 
             // m_target->SetTransform(Matrix3x2F::Rotation(minuteAngle) * m_orientation * translation);
 
-            target.draw_line(
+            target.DrawLine(
                 zero,
                 end,
                 &self.device_dependent_resources.brush,
@@ -339,7 +339,7 @@ impl Clock {
                 x: 0.0,
                 y: -(radius * 0.5),
             };
-            target.draw_line(
+            target.DrawLine(
                 zero,
                 end,
                 &self.device_dependent_resources.brush,
@@ -353,7 +353,7 @@ impl Clock {
 fn create_swapchain_bitmap(swap_chain: &IDXGISwapChain1, target: &ID2D1DeviceContext) {
     let mut surface: Option<IDXGISurface> = None;
     unsafe {
-        HR!(swap_chain.get_buffer(
+        HR!(swap_chain.GetBuffer(
             0,
             &IDXGISurface::IID,
             &mut surface as *mut _ as *mut *mut c_void,
@@ -368,8 +368,8 @@ fn create_swapchain_bitmap(swap_chain: &IDXGISwapChain1, target: &ID2D1DeviceCon
 
         let mut bitmap = None;
 
-        HR!(target.create_bitmap_from_dxgi_surface(surface.unwrap(), &props, &mut bitmap));
-        target.set_target(bitmap.unwrap());
+        HR!(target.CreateBitmapFromDxgiSurface(surface.unwrap(), &props, &mut bitmap));
+        target.SetTarget(bitmap.unwrap());
     }
 }
 
@@ -386,7 +386,7 @@ fn create_swapchain(device: &ID3D11Device, window: HWND) -> IDXGISwapChain1 {
     let mut swap_chain = None;
 
     unsafe {
-        HR!(factory.create_swap_chain_for_hwnd(
+        HR!(factory.CreateSwapChainForHwnd(
             device,
             window,
             &props,
@@ -400,12 +400,12 @@ fn create_swapchain(device: &ID3D11Device, window: HWND) -> IDXGISwapChain1 {
 }
 
 fn get_dxgi_factory(device: &ID3D11Device) -> IDXGIFactory2 {
-    let dxdevice = device.get_interface::<IDXGIDevice>().unwrap();
+    let dxdevice = device.query_interface::<IDXGIDevice>().unwrap();
     let mut adapter = None;
     unsafe {
-        HR!(dxdevice.get_adapter(&mut adapter));
+        HR!(dxdevice.GetAdapter(&mut adapter));
         let mut parent = None;
-        HR!(adapter.unwrap().get_parent(
+        HR!(adapter.unwrap().GetParent(
             &IDXGIFactory2::IID,
             &mut parent as *mut _ as *mut *mut c_void
         ));
@@ -414,16 +414,16 @@ fn get_dxgi_factory(device: &ID3D11Device) -> IDXGIFactory2 {
 }
 
 fn create_render_target(factory: &ID2D1Factory1, device: &mut ID3D11Device) -> ID2D1DeviceContext {
-    let dxdevice = device.get_interface::<IDXGIDevice>();
+    let dxdevice = device.query_interface::<IDXGIDevice>();
 
     let mut d2device = None;
     let target = unsafe {
-        HR!(factory.create_device(&dxdevice, &mut d2device));
+        HR!(factory.CreateDevice(&dxdevice, &mut d2device));
         let mut target = None;
 
         HR!(d2device
             .unwrap()
-            .create_device_context(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &mut target));
+            .CreateDeviceContext(D2D1_DEVICE_CONTEXT_OPTIONS_NONE, &mut target));
         target
     };
 
@@ -493,7 +493,7 @@ fn get_dpi(factory: &ID2D1Factory1) -> f32 {
     let mut dpix: f32 = 0.0;
     let mut dpiy: f32 = 0.0;
     unsafe {
-        factory.get_desktop_dpi(&mut dpix, &mut dpiy);
+        factory.GetDesktopDpi(&mut dpix, &mut dpiy);
     }
     dpix
 }
@@ -513,7 +513,7 @@ impl DeviceIndependentResources {
 
         let mut style = None;
         unsafe {
-            HR!(factory.create_stroke_style(&style_props, std::ptr::null_mut(), 0, &mut style));
+            HR!(factory.CreateStrokeStyle(&style_props, std::ptr::null_mut(), 0, &mut style));
         }
         let style = style.unwrap();
 
@@ -542,20 +542,14 @@ impl DeviceIndependentResources {
         unsafe {
             check_bool!(QueryPerformanceFrequency(&mut animation_frequency));
 
-            HR!(library.create_accelerate_decelerate_transition(
-                5.0,
-                1.0,
-                0.2,
-                0.8,
-                &mut transition,
-            ));
+            HR!(library.CreateAccelerateDecelerateTransition(5.0, 1.0, 0.2, 0.8, &mut transition,));
 
-            HR!(animation_manager.create_animation_variable(0.0, &mut animation_variable));
+            HR!(animation_manager.CreateAnimationVariable(0.0, &mut animation_variable));
         }
         let animation_variable = animation_variable.unwrap();
 
         unsafe {
-            HR!(animation_manager.schedule_transition(
+            HR!(animation_manager.ScheduleTransition(
                 &animation_variable,
                 transition.unwrap(),
                 get_time(animation_frequency)
@@ -585,7 +579,7 @@ impl DeviceDependentResources {
         let swap_chain = create_swapchain(&device, window);
         create_swapchain_bitmap(&swap_chain, &target);
 
-        unsafe { target.set_dpi(dpi, dpi) };
+        unsafe { target.SetDpi(dpi, dpi) };
 
         let brush = create_device_resources(&target);
         let clock = create_device_size_resources(&target, dpi);
@@ -611,7 +605,7 @@ fn create_device_resources(target: &ID2D1DeviceContext) -> ID2D1SolidColorBrush 
 
     let mut brush = None;
     unsafe {
-        HR!(target.create_solid_color_brush(&color_orange, &props, &mut brush));
+        HR!(target.CreateSolidColorBrush(&color_orange, &props, &mut brush));
     }
     brush.unwrap()
 }
@@ -619,7 +613,7 @@ fn create_device_resources(target: &ID2D1DeviceContext) -> ID2D1SolidColorBrush 
 fn create_device_size_resources(target: &ID2D1DeviceContext, dpi: f32) -> ID2D1Bitmap1 {
     let size = unsafe {
         let mut size = std::mem::zeroed();
-        target.get_size(&mut size);
+        target.GetSize(&mut size);
         size
     };
     let size = D2D_SIZE_U {
@@ -639,7 +633,7 @@ fn create_device_size_resources(target: &ID2D1DeviceContext, dpi: f32) -> ID2D1B
     };
     let mut clock = None;
     unsafe {
-        HR!(target.create_bitmap(size, std::ptr::null(), 0, &props, &mut clock));
+        HR!(target.CreateBitmap(size, std::ptr::null(), 0, &props, &mut clock));
     }
 
     // m_shadow = nullptr;
@@ -664,8 +658,8 @@ fn get_time(frequency: winnt::LARGE_INTEGER) -> f64 {
 interfaces! {
     #[uuid("06152247-6f50-465a-9245-118bfd3b6007")]
     unsafe interface ID2D1Factory: IUnknown {
-        fn reload_system_metrics(&self) -> HRESULT;
-        fn get_desktop_dpi(&self, dpi_x: *mut FLOAT, dpi_y: *mut FLOAT);
+        fn ReloadSystemMetrics(&self) -> HRESULT;
+        fn GetDesktopDpi(&self, dpi_x: *mut FLOAT, dpi_y: *mut FLOAT);
         // ununsed functions
         fn f0(&self);
         fn f1(&self);
@@ -683,12 +677,12 @@ interfaces! {
 
     #[uuid("bb12d362-daee-4b9a-aa1d-14ba401cfa1f")]
     unsafe interface ID2D1Factory1: ID2D1Factory {
-        fn create_device(
+        fn CreateDevice(
             &self,
             dxgi_device: Option<IDXGIDevice>,
             d2d_device: *mut Option<ID2D1Device>,
         ) -> HRESULT;
-        fn create_stroke_style(
+        fn CreateStrokeStyle(
             &self,
             stroke_style_properties: *const D2D1_STROKE_STYLE_PROPERTIES1,
             dashes: *const FLOAT,
@@ -700,7 +694,7 @@ interfaces! {
     #[uuid("50c83a1c-e072-4c48-87b0-3630fa36a6d0")]
     unsafe interface IDXGIFactory2: IDXGIFactory1 {
         fn f0(&self);
-        fn create_swap_chain_for_hwnd(
+        fn CreateSwapChainForHwnd(
             &self,
             p_device: IUnknown,
             hwnd: HWND,
@@ -728,7 +722,7 @@ interfaces! {
 
     #[uuid("e8f7fe7a-191c-466d-ad95-975678bda998")]
     unsafe interface ID2D1DeviceContext: ID2D1RenderTarget {
-        fn create_bitmap(
+        fn CreateBitmap(
             &self,
             #[pass_through]
             size: d2d1::D2D1_SIZE_U,
@@ -741,7 +735,7 @@ interfaces! {
         fn f1(&self);
         fn f2(&self);
         fn f3(&self);
-        fn create_bitmap_from_dxgi_surface(
+        fn CreateBitmapFromDxgiSurface(
             &self,
             surface: IDXGISurface,
             bitmap_properties: *const D2D1_BITMAP_PROPERTIES1,
@@ -758,16 +752,16 @@ interfaces! {
         fn f12(&self);
         fn f13(&self);
         fn f14(&self);
-        fn set_target(&self, image: ID2D1Image);
-        fn get_target(&self, image: *mut Option<ID2D1Image>);
+        fn SetTarget(&self, image: ID2D1Image);
+        fn GetTarget(&self, image: *mut Option<ID2D1Image>);
         fn f15(&self);
         fn f16(&self);
         fn f17(&self);
         fn f18(&self);
-        fn set_unit_mode(&self, unit_mode: D2D1_UNIT_MODE);
+        fn SetUnitMode(&self, unit_mode: D2D1_UNIT_MODE);
         fn f19(&self);
         fn f20(&self);
-        fn draw_image(
+        fn DrawImage(
             &self,
             image: ID2D1Image,
             target_offset: *const d2d1::D2D1_POINT_2F,
@@ -781,7 +775,7 @@ interfaces! {
 
     #[uuid("47dd575d-ac05-4cdd-8049-9b02cd16f44c")]
     unsafe interface ID2D1Device: ID2D1Resource {
-        fn create_device_context(
+        fn CreateDeviceContext(
             &self,
             options: D2D1_DEVICE_CONTEXT_OPTIONS,
             device_context: *mut Option<ID2D1DeviceContext>,
@@ -794,7 +788,7 @@ interfaces! {
         fn f1(&self);
         fn f2(&self);
         fn f3(&self);
-        fn create_solid_color_brush(
+        fn CreateSolidColorBrush(
             &self,
             color: *const D2D1_COLOR_F,
             brush_props: *const D2D1_BRUSH_PROPERTIES,
@@ -806,7 +800,7 @@ interfaces! {
         fn f7(&self);
         fn f8(&self);
         fn f9(&self);
-        fn draw_line(
+        fn DrawLine(
             &self,
             #[pass_through]
             point0: d2d1::D2D1_POINT_2F,
@@ -820,7 +814,7 @@ interfaces! {
         fn f11(&self);
         fn f12(&self);
         fn f13(&self);
-        fn draw_ellipse(
+        fn DrawEllipse(
             &self,
             ellipse: *const D2D1_ELLIPSE,
             brush: ID2D1Brush,
@@ -836,8 +830,8 @@ interfaces! {
         fn f20(&self);
         fn f21(&self);
         fn f22(&self);
-        fn set_transform(&self, transform: *const d2d1::D2D1_MATRIX_3X2_F);
-        fn get_transform(&self, transform: *mut d2d1::D2D1_MATRIX_3X2_F);
+        fn SetTransform(&self, transform: *const d2d1::D2D1_MATRIX_3X2_F);
+        fn GetTransform(&self, transform: *mut d2d1::D2D1_MATRIX_3X2_F);
         fn f23(&self);
         fn f24(&self);
         fn f25(&self);
@@ -853,17 +847,17 @@ interfaces! {
         fn f35(&self);
         fn f36(&self);
         fn f37(&self);
-        fn clear(&self, clear_color: *const D2D1_COLOR_F);
-        fn begin_draw(&self);
-        fn end_draw(
+        fn Clear(&self, clear_color: *const D2D1_COLOR_F);
+        fn BeginDraw(&self);
+        fn EndDraw(
             &self,
             tag1: *mut D2D1_TAG,
             tag2: *mut D2D1_TAG,
         );
         fn f38(&self);
-        fn set_dpi(&self, dpix: f32, dpiy: f32);
+        fn SetDpi(&self, dpix: f32, dpiy: f32);
         fn f39(&self);
-        fn get_size(&self, ret: *mut d2d1::D2D1_SIZE_F) ;
+        fn GetSize(&self, ret: *mut d2d1::D2D1_SIZE_F) ;
         fn f40(&self);
         fn f41(&self);
         fn f42(&self);
@@ -879,7 +873,7 @@ interfaces! {
 
     #[uuid("54ec77fa-1377-44e6-8c32-88fd5f44c84c")]
     unsafe interface IDXGIDevice: IDXGIObject {
-        fn get_adapter(&self, adapter: *mut Option<IDXGIAdapter>) -> HRESULT;
+        fn GetAdapter(&self, adapter: *mut Option<IDXGIAdapter>) -> HRESULT;
         fn f0(&self);
         fn f1(&self);
         fn f2(&self);
@@ -890,7 +884,7 @@ interfaces! {
         fn f0(&self);
         fn f1(&self);
         fn f2(&self);
-        fn get_parent(
+        fn GetParent(
             &self,
             refid: *const com::IID,
             pparent: *mut *mut c_void,
@@ -902,12 +896,12 @@ interfaces! {
 
     #[uuid("310d36a0-d2e7-4c0a-aa04-6a9d23b8886a")]
     unsafe interface IDXGISwapChain: IDXGIDeviceSubObject {
-        fn present(
+        fn Present(
             &self,
             sync_interval: UINT,
             flags: UINT,
         ) -> HRESULT;
-        fn get_buffer(
+        fn GetBuffer(
             &self,
             buffer: UINT,
             riid: *const com::IID,
@@ -944,12 +938,12 @@ interfaces! {
 
     #[uuid("9169896C-AC8D-4e7d-94E5-67FA4DC2F2E8")]
     unsafe interface IUIAnimationManager: IUnknown {
-        fn create_animation_variable(
+        fn CreateAnimationVariable(
             &self,
             initial_value: f64,
             out: *mut Option<IUIAnimationVariable>,
         ) -> HRESULT;
-        fn schedule_transition(
+        fn ScheduleTransition(
             &self,
             var: IUIAnimationVariable,
             transition: IUIAnimationTransition,
@@ -958,7 +952,7 @@ interfaces! {
         fn f0(&self);
         fn f1(&self);
         fn f2(&self);
-        fn update(&self, time_now: UI_ANIMATION_SECONDS, _ptr: *mut c_void)
+        fn Update(&self, time_now: UI_ANIMATION_SECONDS, _ptr: *mut c_void)
             -> HRESULT;
     }
 
@@ -976,7 +970,7 @@ interfaces! {
 
     #[uuid("8CEEB155-2849-4ce5-9448-91FF70E1E4D9")]
     unsafe interface IUIAnimationVariable: IUnknown {
-        fn get_value(&self, value: *mut f64) -> HRESULT;
+        fn GetValue(&self, value: *mut f64) -> HRESULT;
     }
 
     #[uuid("CA5A14B1-D24F-48b8-8FE4-C78169BA954E")]
@@ -988,7 +982,7 @@ interfaces! {
         fn f4(&self);
         fn f5(&self);
         fn f6(&self);
-        pub fn create_accelerate_decelerate_transition(
+        pub fn CreateAccelerateDecelerateTransition(
             &self,
             duration: UI_ANIMATION_SECONDS,
             fin: f64,

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -31,7 +31,7 @@ pub fn generate(class: &Class) -> TokenStream {
                     }
 
                     let instance = #class_name::allocate(#(#user_fields)*,);
-                    instance.query_interface(riid, ppv)
+                    instance.QueryInterface(riid, ppv)
                 }
 
                 unsafe fn LockServer(&self, _increment: com::sys::BOOL) -> com::sys::HRESULT {

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -82,7 +82,7 @@ impl Interface {
         quote! {
             impl Drop for #name {
                 fn drop(&mut self) {
-                    unsafe { <Self as ::com::Interface>::as_iunknown(self).release(); }
+                    unsafe { <Self as ::com::Interface>::as_iunknown(self).Release(); }
                 }
             }
         }
@@ -95,7 +95,7 @@ impl Interface {
             impl ::std::clone::Clone for #name {
                 fn clone(&self) -> Self {
                     unsafe {
-                        <Self as ::com::Interface>::as_iunknown(self).add_ref();
+                        <Self as ::com::Interface>::as_iunknown(self).AddRef();
                     }
                     Self {
                         inner: self.inner
@@ -315,6 +315,7 @@ impl InterfaceMethod {
         let docs = &self.docs;
         let vis = &self.visibility;
         return quote! {
+            #[allow(non_snake_case)]
             #(#docs)*
             #vis unsafe fn #outer_method_ident<#(#generics),*>(&self, #(#args),*) #return_type {
                 #(#into)*

--- a/src/interfaces/iclass_factory.rs
+++ b/src/interfaces/iclass_factory.rs
@@ -10,23 +10,25 @@ interfaces! {
     #[uuid("00000001-0000-0000-c000-000000000046")]
     pub unsafe interface IClassFactory: IUnknown {
         /// the [CreateInstance](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iclassfactory-createinstance) COM method
-        pub unsafe fn create_instance(
+        pub unsafe fn CreateInstance(
             &self,
             aggr: Option<IUnknown>,
             riid: *const GUID,
             ppv: *mut *mut c_void,
         ) -> HRESULT;
         /// the [LockServer](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iclassfactory-lockserver) COM method
-        pub unsafe fn lock_server(&self, increment: BOOL) -> HRESULT;
+        pub unsafe fn LockServer(&self, increment: BOOL) -> HRESULT;
     }
 }
 
 impl IClassFactory {
-    /// Get an instance of the associated Co Class
-    pub fn get_instance<T: Interface>(&self) -> Option<T> {
+    /// Create an instance of the associated class
+    ///
+    /// This is a safe wrapper around `CreateInstance`
+    pub fn create_instance<T: Interface>(&self) -> Option<T> {
         let mut ppv = None;
         let hr =
-            unsafe { self.create_instance(None, &T::IID, &mut ppv as *mut _ as *mut *mut c_void) };
+            unsafe { self.CreateInstance(None, &T::IID, &mut ppv as *mut _ as *mut *mut c_void) };
         if FAILED(hr) {
             // TODO: decide what failures are possible
             return None;

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -13,12 +13,12 @@ interfaces! {
         /// The COM [`QueryInterface` Method]
         ///
         /// This method normally should not be called directly. Interfaces that implement
-        /// `IUnknown` also implement [`IUnknown::get_interface`] which is a safe wrapper around
-        /// `IUnknown::query_interface`.
+        /// `IUnknown` also implement [`IUnknown::query_interface`] which is a safe wrapper around
+        /// `IUnknown::QueryInterface`.
         ///
         /// [`QueryInterface` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)
-        /// [`IUnknown::get_interface`]: trait.IUnknown.html#method.get_interface
-        pub unsafe fn query_interface(&self, riid: *const GUID, ppv: *mut *mut c_void) -> HRESULT;
+        /// [`IUnknown::query_interface`]: trait.IUnknown.html#method.query_interface
+        pub unsafe fn QueryInterface(&self, riid: *const GUID, ppv: *mut *mut c_void) -> HRESULT;
 
         /// The COM [`AddRef` Method]
         ///
@@ -27,7 +27,7 @@ interfaces! {
         ///
         /// [`AddRef` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref
         /// [`ComPtr`]: struct.ComPtr.html
-        pub unsafe fn add_ref(&self) -> u32;
+        pub unsafe fn AddRef(&self) -> u32;
 
         /// The COM [`Release` Method]
         ///
@@ -36,7 +36,7 @@ interfaces! {
         ///
         /// [`Release` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release
         /// [`ComPtr`]: struct.ComPtr.html
-        pub unsafe fn release(&self) -> u32;
+        pub unsafe fn Release(&self) -> u32;
     }
 
 }
@@ -47,10 +47,10 @@ impl IUnknown {
     /// If the backing class implements the interface `I` then a `Some`
     /// containing an `ComPtr` pointing to that interface will be returned
     /// otherwise `None` will be returned.
-    pub fn get_interface<I: Interface>(&self) -> Option<I> {
+    pub fn query_interface<I: Interface>(&self) -> Option<I> {
         let mut ppv = None;
         let hr = unsafe {
-            self.query_interface(
+            self.QueryInterface(
                 &I::IID as *const IID,
                 &mut ppv as *mut _ as *mut *mut c_void,
             )

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -210,10 +210,10 @@ macro_rules! inproc_dll_module {
             let class_id = unsafe { &*class_id };
             if class_id == &$class_id_one {
                 let instance = <$class_type_one as ::com::production::Class>::Factory::allocate();
-                instance.query_interface(&*iid, result)
+                instance.QueryInterface(&*iid, result)
             } $(else if class_id == &$class_id {
                 let instance = <$class_type_one as ::com::production::Class>::Factory::allocate();
-                instance.query_interface(&*iid, result)
+                instance.QueryInterface(&*iid, result)
             })* else {
                 ::com::sys::CLASS_E_CLASSNOTAVAILABLE
             }


### PR DESCRIPTION
This fixes the concern that @kennykerr had where safe versions of COM methods had different names (to avoid name conflicts). This change makes raw COM methods use CamelCasing (e.g., `QueryInterface`) while safe versions use the more idiomatic camel_case style (e.g., `query_interface`).