### PR TITLE
Enable all features when compiling for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ trybuild = "1.0"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
+all-features = true
 
 [workspace]
 members = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! # fn main() {}
 //! ```
 //!
-//!  To define a COM implementation class:
+//! To define a COM implementation class:
 //!
 //! ```rust,no_run
 //! # com::interfaces! {
@@ -28,7 +28,7 @@
 //!     pub class BritishShortHairCat: IAnimal {
 //!         num_owners: u32,
 //!     }
-//!     
+//!
 //!     impl IAnimal for BritishShortHairCat {
 //!         fn Eat(&self) -> com::sys::HRESULT {
 //!             println!("Eating...");
@@ -96,7 +96,7 @@ pub use com_macros::interfaces;
 ///     pub class BritishShortHairCat: IAnimal {
 ///         num_owners: u32,
 ///     }
-///     
+///
 ///     impl IAnimal for BritishShortHairCat {
 ///         fn Eat(&self) -> HRESULT {
 ///             println!("Eating...");


### PR DESCRIPTION
Currently both the reexported production module and class macro do not appear on docs.rs because they are gated behind a feature cfg. Enabling all features when compiling for docs.rs should make them show up again.

---

I've not been able to properly test this as `cargo doc --open` doesn't seem to take `package.metadata.docs.rs` into account, and I can't find if there's a special flag to make it do such a build.
