### PR TITLE
fix com::class! class with multiple fields

### DIFF
--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -30,7 +30,7 @@ pub fn generate(class: &Class) -> TokenStream {
                         return ::com::sys::CLASS_E_NOAGGREGATION;
                     }
 
-                    let instance = #class_name::allocate(#(#user_fields)*,);
+                    let instance = #class_name::allocate(#(#user_fields),*);
                     instance.QueryInterface(riid, ppv)
                 }
 

--- a/tests/ui/pass/class_fields.rs
+++ b/tests/ui/pass/class_fields.rs
@@ -1,0 +1,28 @@
+com::interfaces! {
+    #[uuid("12345678-1234-1234-1234-12345678ABCD")]
+    pub unsafe interface ISomething: com::interfaces::iunknown::IUnknown {}
+}
+
+com::class! {
+    pub class ClassOfZero: ISomething {
+    }
+
+    impl ISomething for SomeClass {}
+}
+com::class! {
+    pub class ClassOfOne: ISomething {
+        one: u32,
+    }
+
+    impl ISomething for SomeClass {}
+}
+com::class! {
+    pub class ClassOfTwo: ISomething {
+        one: u32,
+        two: u32
+    }
+
+    impl ISomething for SomeClass {}
+}
+
+fn main() {}


### PR DESCRIPTION
Having multiple fields in a class does not compile. This change makes the code below compile as expected.

```
com::class! {
    pub class BritishShortHairCat: IAnimal {
        hello: u32,
        hi: u32
    }
[...]
}
```

Fixes #186