### PR TITLE
Support for no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ members = [
     "examples/basic/server",
     "examples/basic/client",
     "examples/basic/interface",
-    "examples/d2d-clock"
+    "examples/d2d-clock",
+    "examples/lib_no_std",
 ]
 
 [[example]]

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -71,7 +71,7 @@ impl Drop for IAnimal {
 }
 
 // Cloning the interface increases its reference count.
-impl ::std::clone::Clone for IAnimal {
+impl ::core::clone::Clone for IAnimal {
     fn clone(&self) -> Self {
         unsafe {
             <Self as com::Interface>::as_iunknown(self).AddRef();
@@ -113,19 +113,19 @@ impl std::convert::From<IAnimal> for IUnknown {
         unsafe { std::mem::transmute(this) }
     }
 }
-impl<'a> ::std::convert::From<&'a IAnimal> for &'a IUnknown {
+impl<'a> ::core::convert::From<&'a IAnimal> for &'a IUnknown {
     fn from(this: &'a IAnimal) -> Self {
-        unsafe { ::std::mem::transmute(this) }
+        unsafe { ::core::mem::transmute(this) }
     }
 }
 
 // Allow this interface to be passed as a param to method which takes its parent
-impl<'a> ::std::convert::Into<::com::Param<'a, IUnknown>> for IAnimal {
+impl<'a> ::core::convert::Into<::com::Param<'a, IUnknown>> for IAnimal {
     fn into(self) -> ::com::Param<'a, IUnknown> {
         ::com::Param::Owned(self.into())
     }
 }
-impl<'a> ::std::convert::Into<::com::Param<'a, IUnknown>> for &'a IAnimal {
+impl<'a> ::core::convert::Into<::com::Param<'a, IUnknown>> for &'a IAnimal {
     fn into(self) -> ::com::Param<'a, IUnknown> {
         ::com::Param::Borrowed(self.into())
     }

--- a/examples/lib_no_std/Cargo.toml
+++ b/examples/lib_no_std/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lib_no_std"
+version = "0.1.0"
+authors = ["Microsoft Corp"]
+edition = "2018"
+
+[dependencies]
+com = { path = "../.." }

--- a/examples/lib_no_std/src/lib.rs
+++ b/examples/lib_no_std/src/lib.rs
@@ -1,0 +1,27 @@
+//! This demonstrates that COM can be used in a `#![no_std]` environment.
+
+#![no_std]
+
+use com::interfaces::IUnknown;
+
+com::interfaces! {
+    #[uuid("f6681e01-0a99-47ce-8c04-71e82742c103")]
+    pub unsafe interface IFoo : IUnknown {
+        pub fn do_the_foo(&self, x: u32) -> u32;
+    }
+}
+
+pub fn hello_world(foo: &IFoo) -> u32 {
+    unsafe { foo.do_the_foo(42) }
+}
+
+pub fn maybe_hello_world(unknown: &IUnknown) -> Option<IFoo> {
+    if let Some(foo) = unknown.query_interface::<IFoo>() {
+        unsafe {
+            foo.do_the_foo(100);
+        }
+        Some(foo)
+    } else {
+        None
+    }
+}

--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -31,10 +31,10 @@ pub fn generate(class: &Class) -> TokenStream {
             #interface_inits
             let instance = #name {
                 #interface_fields
-                #ref_count_ident: ::std::cell::Cell::new(1),
+                #ref_count_ident: ::core::cell::Cell::new(1),
                 #(#user_fields),*
             };
-            let instance = ::std::boxed::Box::pin(instance);
+            let instance = ::core::boxed::Box::pin(instance);
             ::com::production::ClassAllocation::new(instance)
         }
     }
@@ -59,7 +59,7 @@ fn gen_vpointer_inits(class: &Class) -> TokenStream {
             let interface = interface.to_initialized_vtable_tokens(class, index);
             let vptr_field_ident = quote::format_ident!("__{}", index);
             quote! {
-                let #vptr_field_ident = unsafe { ::std::ptr::NonNull::new_unchecked(::std::boxed::Box::into_raw(::std::boxed::Box::new(#interface))) };
+                let #vptr_field_ident = unsafe { ::core::ptr::NonNull::new_unchecked(::alloc::boxed::Box::into_raw(::alloc::boxed::Box::new(#interface))) };
             }
         });
 

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -11,7 +11,7 @@ pub fn generate(class: &Class) -> TokenStream {
     let class_name = &class.name;
     let user_fields = class.fields.iter().map(|f| {
         let ty = &f.ty;
-        quote! { <#ty as ::std::default::Default>::default() }
+        quote! { <#ty as ::core::default::Default>::default() }
     });
     quote! {
         ::com::class! {
@@ -21,12 +21,12 @@ pub fn generate(class: &Class) -> TokenStream {
             impl ::com::interfaces::IClassFactory for #class_factory_ident {
                 unsafe fn CreateInstance(
                     &self,
-                    aggr: *mut ::std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
+                    aggr: *mut ::core::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
                     riid: *const ::com::sys::IID,
-                    ppv: *mut *mut ::std::ffi::c_void,
+                    ppv: *mut *mut ::core::ffi::c_void,
                 ) -> ::com::sys::HRESULT {
                     assert!(!riid.is_null(), "iid passed to CreateInstance was null");
-                    if aggr != ::std::ptr::null_mut() {
+                    if aggr != ::core::ptr::null_mut() {
                         return ::com::sys::CLASS_E_NOAGGREGATION;
                     }
 

--- a/macros/support/src/class/iunknown_impl.rs
+++ b/macros/support/src/class/iunknown_impl.rs
@@ -47,7 +47,7 @@ impl IUnknownAbi {
             unsafe extern "stdcall" fn QueryInterface(
                 this: #this_ptr,
                 riid: *const ::com::sys::IID,
-                ppv: *mut *mut ::std::ffi::c_void
+                ppv: *mut *mut ::core::ffi::c_void
             ) -> ::com::sys::HRESULT {
                 #munge
                 munged.QueryInterface(riid, ppv)
@@ -70,7 +70,7 @@ impl IUnknownAbi {
 
         quote! {
             #owned
-            let munged = ::std::mem::ManuallyDrop::new(munged);
+            let munged = ::core::mem::ManuallyDrop::new(munged);
         }
     }
 }
@@ -85,7 +85,7 @@ impl IUnknown {
     pub fn to_add_ref_tokens(&self) -> TokenStream {
         let ref_count_ident = crate::utils::ref_count_ident();
         quote! {
-            pub unsafe fn AddRef(self: &::std::pin::Pin<::std::boxed::Box<Self>>) -> u32 {
+            pub unsafe fn AddRef(self: &::core::pin::Pin<::alloc::boxed::Box<Self>>) -> u32 {
                 let value = self.#ref_count_ident.get().checked_add(1).expect("Overflow of reference count");
                 self.#ref_count_ident.set(value);
                 value
@@ -99,18 +99,18 @@ impl IUnknown {
 
         quote! {
             pub unsafe fn QueryInterface(
-                self: &::std::pin::Pin<::std::boxed::Box<Self>>,
+                self: &::core::pin::Pin<::alloc::boxed::Box<Self>>,
                 riid: *const ::com::sys::IID,
-                ppv: *mut *mut ::std::ffi::c_void
+                ppv: *mut *mut ::core::ffi::c_void
             ) -> ::com::sys::HRESULT {
                 let riid = &*riid;
 
                 if riid == &::com::interfaces::iunknown::IID_IUNKNOWN {
                     // Cast the &Pin<Box<T>> as a pointer and then dereference
                     // it to get the Pin<Box> as a pointer
-                    *ppv = *(self as *const _ as *const *mut ::std::ffi::c_void);
+                    *ppv = *(self as *const _ as *const *mut ::core::ffi::c_void);
                 } #base_match_arms else {
-                    *ppv = ::std::ptr::null_mut::<::std::ffi::c_void>();
+                    *ppv = ::core::ptr::null_mut::<::core::ffi::c_void>();
                     return ::com::sys::E_NOINTERFACE;
                 }
 
@@ -129,7 +129,7 @@ impl IUnknown {
                 else if <#interface as ::com::Interface>::is_iid_in_inheritance_chain(riid) {
                     // Cast the &Pin<Box<T>> as a pointer and then dereference
                     // it to get the Pin<Box> as a pointer
-                    *ppv = (*(self as *const _ as *const *mut usize)).add(#index) as *mut ::std::ffi::c_void;
+                    *ppv = (*(self as *const _ as *const *mut usize)).add(#index) as *mut ::core::ffi::c_void;
                 }
             }
         });
@@ -140,6 +140,6 @@ impl IUnknown {
 
 fn this_ptr_type() -> TokenStream {
     quote! {
-        ::std::ptr::NonNull<::std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>>
+        ::core::ptr::NonNull<::core::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>>
     }
 }

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -26,7 +26,7 @@ impl Interface {
             #[repr(transparent)]
             #[derive(Debug)]
             #vis struct #name {
-                inner: ::std::ptr::NonNull<#vptr>,
+                inner: ::core::ptr::NonNull<#vptr>,
             }
             #impl_block
         }
@@ -67,10 +67,10 @@ impl Interface {
         let name = &self.name;
 
         quote! {
-            impl ::std::ops::Deref for #name {
+            impl ::core::ops::Deref for #name {
                 type Target = <#name as ::com::Interface>::Super;
                 fn deref(&self) -> &Self::Target {
-                    unsafe { ::std::mem::transmute(self) }
+                    unsafe { ::core::mem::transmute(self) }
                 }
             }
         }
@@ -92,7 +92,7 @@ impl Interface {
         let name = &self.name;
 
         quote! {
-            impl ::std::clone::Clone for #name {
+            impl ::core::clone::Clone for #name {
                 fn clone(&self) -> Self {
                     unsafe {
                         <Self as ::com::Interface>::as_iunknown(self).AddRef();
@@ -300,7 +300,7 @@ impl InterfaceMethod {
             } else {
                 let generic = quote::format_ident!("__{}", index);
                 args.push(quote! { #pat: #generic });
-                generics.push(quote! { #generic: ::std::convert::Into<::com::Param<'a, #ty>> });
+                generics.push(quote! { #generic: ::core::convert::Into<::com::Param<'a, #ty>> });
 
                 // note: we separate the call to `into` and `get_abi` so that the `param`
                 // binding lives to the end of the method.

--- a/macros/support/src/interface/mod.rs
+++ b/macros/support/src/interface/mod.rs
@@ -37,22 +37,22 @@ fn convert_impls(parents: HashMap<Ident, Path>) -> Vec<TokenStream> {
         let mut current = &name;
         while let Some(p) = parents.get(current) {
             result.push(quote::quote! {
-                impl ::std::convert::From<#name> for #p {
+                impl ::core::convert::From<#name> for #p {
                     fn from(this: #name) -> Self {
-                        unsafe { ::std::mem::transmute(this) }
+                        unsafe { ::core::mem::transmute(this) }
                     }
                 }
-                impl <'a> ::std::convert::From<&'a #name> for &'a #p {
+                impl <'a> ::core::convert::From<&'a #name> for &'a #p {
                     fn from(this: &'a #name) -> Self {
-                        unsafe { ::std::mem::transmute(this) }
+                        unsafe { ::core::mem::transmute(this) }
                     }
                 }
-                impl <'a> ::std::convert::Into<::com::Param<'a, #p>> for #name {
+                impl <'a> ::core::convert::Into<::com::Param<'a, #p>> for #name {
                     fn into(self) -> ::com::Param<'a, #p> {
                         ::com::Param::Owned(self.into())
                     }
                 }
-                impl <'a> ::std::convert::Into<::com::Param<'a, #p>> for &'a #name {
+                impl <'a> ::core::convert::Into<::com::Param<'a, #p>> for &'a #name {
                     fn into(self) -> ::com::Param<'a, #p> {
                         ::com::Param::Borrowed(self.into())
                     }

--- a/macros/support/src/interface/vptr.rs
+++ b/macros/support/src/interface/vptr.rs
@@ -10,7 +10,7 @@ pub fn generate(interface: &Interface) -> TokenStream {
 
     quote!(
         #[allow(missing_docs)]
-        #vis type #vptr_ident = ::std::ptr::NonNull<#vtable_ident>;
+        #vis type #vptr_ident = ::core::ptr::NonNull<#vtable_ident>;
     )
 }
 

--- a/macros/support/src/interface/vtable.rs
+++ b/macros/support/src/interface/vtable.rs
@@ -73,7 +73,7 @@ fn gen_vtable_function_signature(
 fn gen_raw_params(interface_ident: &Ident, method: &InterfaceMethod) -> syn::Result<TokenStream> {
     let vptr_ident = vptr::ident(&interface_ident);
     let mut params = vec![quote!(
-        ::std::ptr::NonNull<#vptr_ident>,
+        ::core::ptr::NonNull<#vptr_ident>,
     )];
 
     for param in method.args.iter() {

--- a/src/abi_transferable.rs
+++ b/src/abi_transferable.rs
@@ -116,13 +116,13 @@ unsafe impl<T: crate::Interface> AbiTransferable for Option<T> {
     fn get_abi(&self) -> Self::Abi {
         self.as_ref()
             .map(|p| p.as_raw().as_ptr())
-            .unwrap_or(::std::ptr::null_mut())
+            .unwrap_or(::core::ptr::null_mut())
     }
 
     fn set_abi(&mut self) -> *mut Self::Abi {
         &mut self
             .as_mut()
             .map(|p| p.as_raw().as_ptr())
-            .unwrap_or(::std::ptr::null_mut())
+            .unwrap_or(::core::ptr::null_mut())
     }
 }

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -23,16 +23,15 @@ interfaces! {
         /// The COM [`AddRef` Method]
         ///
         /// This method normally should not be called directly. This method is used by
-        /// [`ComPtr`] to implement the reference counting mechanism.
+        /// the `Clone` implementation of interfaces to implement the reference counting mechanism.
         ///
         /// [`AddRef` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref
-        /// [`ComPtr`]: struct.ComPtr.html
         pub unsafe fn AddRef(&self) -> u32;
 
         /// The COM [`Release` Method]
         ///
         /// This method normally should not be called directly. This method is used by
-        /// [`ComPtr`] to implement the reference counting mechanism.
+        /// the `Drop` implementation of interfaces to implement the reference counting mechanism.
         ///
         /// [`Release` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release
         /// [`ComPtr`]: struct.ComPtr.html

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -175,9 +175,9 @@ pub fn dll_unregister_server(relevant_keys: &mut Vec<RegistryKeyInfo>) -> HRESUL
 #[macro_export]
 macro_rules! inproc_dll_module {
     (($class_id_one:ident, $class_type_one:ty), $(($class_id:ident, $class_type:ty)),*) => {
-        static mut _HMODULE: *mut ::std::ffi::c_void = ::std::ptr::null_mut();
+        static mut _HMODULE: *mut ::core::ffi::c_void = ::core::ptr::null_mut();
         #[no_mangle]
-        unsafe extern "stdcall" fn DllMain(hinstance: *mut ::std::ffi::c_void, fdw_reason: u32, reserved: *mut ::std::ffi::c_void) -> i32 {
+        unsafe extern "stdcall" fn DllMain(hinstance: *mut ::core::ffi::c_void, fdw_reason: u32, reserved: *mut ::core::ffi::c_void) -> i32 {
             const DLL_PROCESS_ATTACH: u32 = 1;
             if fdw_reason == DLL_PROCESS_ATTACH {
                 unsafe { _HMODULE = hinstance; }
@@ -186,7 +186,7 @@ macro_rules! inproc_dll_module {
         }
 
         #[no_mangle]
-        unsafe extern "stdcall" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::std::ffi::c_void) -> ::com::sys::HRESULT {
+        unsafe extern "stdcall" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::core::ffi::c_void) -> ::com::sys::HRESULT {
             use ::com::interfaces::IUnknown;
             assert!(!class_id.is_null(), "class id passed to DllGetClassObject should never be null");
 


### PR DESCRIPTION
This changes the generated code so that it uses the `core` crate (where applicable) instead of the `std` crate. Almost everything in the generated code can directly use `core`, with the only exceptions being allocation container types, like `Box`. These are changed to use `alloc::boxed::Box`.

This allows the generated code to work in crates that are using `#![no_std]`. I've also added a very simple example crate that demonstrates using `com-rs` with `#![no_std]`.

Also, I edited the doc comments for `IUnknown::AddRef` and `IUnknown::Release`. They contained references to a `ComPtr` type, which no longer exists.
