### PR TITLE
Support for no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ readme = "./README.md"
 com_macros = { version = "0.3", path = "macros" }
 
 [features]
-production = []
+default = ["std"]
+# Production requires std because production::registration uses CString.
+production = ["std"]
+std = []
 
 [[test]]
 name = "tests"
@@ -37,7 +40,8 @@ members = [
     "examples/basic/server",
     "examples/basic/client",
     "examples/basic/interface",
-    "examples/d2d-clock"
+    "examples/d2d-clock",
+    "examples/lib_no_std",
 ]
 
 [[example]]

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -71,7 +71,7 @@ impl Drop for IAnimal {
 }
 
 // Cloning the interface increases its reference count.
-impl ::std::clone::Clone for IAnimal {
+impl ::core::clone::Clone for IAnimal {
     fn clone(&self) -> Self {
         unsafe {
             <Self as com::Interface>::as_iunknown(self).AddRef();
@@ -113,19 +113,19 @@ impl std::convert::From<IAnimal> for IUnknown {
         unsafe { std::mem::transmute(this) }
     }
 }
-impl<'a> ::std::convert::From<&'a IAnimal> for &'a IUnknown {
+impl<'a> ::core::convert::From<&'a IAnimal> for &'a IUnknown {
     fn from(this: &'a IAnimal) -> Self {
-        unsafe { ::std::mem::transmute(this) }
+        unsafe { ::core::mem::transmute(this) }
     }
 }
 
 // Allow this interface to be passed as a param to method which takes its parent
-impl<'a> ::std::convert::Into<::com::Param<'a, IUnknown>> for IAnimal {
+impl<'a> ::core::convert::Into<::com::Param<'a, IUnknown>> for IAnimal {
     fn into(self) -> ::com::Param<'a, IUnknown> {
         ::com::Param::Owned(self.into())
     }
 }
-impl<'a> ::std::convert::Into<::com::Param<'a, IUnknown>> for &'a IAnimal {
+impl<'a> ::core::convert::Into<::com::Param<'a, IUnknown>> for &'a IAnimal {
     fn into(self) -> ::com::Param<'a, IUnknown> {
         ::com::Param::Borrowed(self.into())
     }

--- a/examples/lib_no_std/Cargo.toml
+++ b/examples/lib_no_std/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "lib_no_std"
+version = "0.1.0"
+authors = ["Microsoft Corp"]
+edition = "2018"
+
+[dependencies]
+com = { path = "../.." }

--- a/examples/lib_no_std/src/lib.rs
+++ b/examples/lib_no_std/src/lib.rs
@@ -1,0 +1,27 @@
+//! This demonstrates that COM can be used in a `#![no_std]` environment.
+
+#![no_std]
+
+use com::interfaces::IUnknown;
+
+com::interfaces! {
+    #[uuid("f6681e01-0a99-47ce-8c04-71e82742c103")]
+    pub unsafe interface IFoo : IUnknown {
+        pub fn do_the_foo(&self, x: u32) -> u32;
+    }
+}
+
+pub fn hello_world(foo: &IFoo) -> u32 {
+    unsafe { foo.do_the_foo(42) }
+}
+
+pub fn maybe_hello_world(unknown: &IUnknown) -> Option<IFoo> {
+    if let Some(foo) = unknown.query_interface::<IFoo>() {
+        unsafe {
+            foo.do_the_foo(100);
+        }
+        Some(foo)
+    } else {
+        None
+    }
+}

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -120,7 +120,7 @@ impl Class {
             let interface_name = &interface.path;
             let field_ident = quote::format_ident!("__{}", index);
             quote! {
-                #field_ident: ::std::ptr::NonNull<<#interface_name as ::com::Interface>::VTable>
+                #field_ident: ::core::ptr::NonNull<<#interface_name as ::com::Interface>::VTable>
             }
         });
         let ref_count_ident = crate::utils::ref_count_ident();
@@ -141,7 +141,7 @@ impl Class {
         let interface_drops = interfaces.iter().enumerate().map(|(index, _)| {
             let field_ident = quote::format_ident!("__{}", index);
             quote! {
-                let _ = ::std::boxed::Box::from_raw(self.#field_ident.as_ptr());
+                let _ = ::com::alloc::boxed::Box::from_raw(self.#field_ident.as_ptr());
             }
         });
         let debug = self.debug();
@@ -152,7 +152,7 @@ impl Class {
             #[repr(C)]
             #vis struct #name {
                 #(#interface_fields,)*
-                #ref_count_ident: ::std::cell::Cell<u32>,
+                #ref_count_ident: ::core::cell::Cell<u32>,
                 #(#user_fields),*
             }
             impl #name {
@@ -163,7 +163,7 @@ impl Class {
                 #safe_query_interface
             }
             #debug
-            impl ::std::ops::Drop for #name {
+            impl ::core::ops::Drop for #name {
                 fn drop(&mut self) {
                     unsafe {
                         #(#interface_drops)*
@@ -205,14 +205,14 @@ impl Class {
         let fields = self.fields.iter().map(|f| {
             let name = f.ident.as_ref().unwrap();
             quote! {
-                .field(::std::stringify!(#name), &self.#name)
+                .field(::core::stringify!(#name), &self.#name)
             }
         });
 
         quote! {
-            impl ::std::fmt::Debug for #name {
-                 fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    f.debug_struct(::std::stringify!(#name))
+            impl ::core::fmt::Debug for #name {
+                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                    f.debug_struct(::core::stringify!(#name))
                         #(#fields)*
                         .finish()
                     }
@@ -222,7 +222,7 @@ impl Class {
 
     fn safe_query_interface(&self) -> TokenStream {
         quote! {
-            pub fn query_interface<T: ::com::Interface>(self: &::std::pin::Pin<::std::boxed::Box<Self>>) -> Option<T> {
+            pub fn query_interface<T: ::com::Interface>(self: &::core::pin::Pin<::com::alloc::boxed::Box<Self>>) -> Option<T> {
                 let mut result = None;
                 let hr = unsafe { self.QueryInterface(&T::IID, &mut result as *mut _ as _) };
 
@@ -386,9 +386,9 @@ impl Interface {
             let ret = &m.sig.output;
             let method = quote! {
                 #[allow(non_snake_case)]
-                unsafe extern "stdcall" fn #name(this: ::std::ptr::NonNull<::std::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
+                unsafe extern "stdcall" fn #name(this: ::core::ptr::NonNull<::core::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
                     let this = this.as_ptr().sub(#offset);
-                    let this = ::std::mem::ManuallyDrop::new(::com::production::ClassAllocation::from_raw(this as *mut _ as *mut #class_name));
+                    let this = ::core::mem::ManuallyDrop::new(::com::production::ClassAllocation::from_raw(this as *mut _ as *mut #class_name));
                     #(#translation)*
                     #class_name::#name(&this, #(#args),*)
                 }

--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -31,10 +31,10 @@ pub fn generate(class: &Class) -> TokenStream {
             #interface_inits
             let instance = #name {
                 #interface_fields
-                #ref_count_ident: ::std::cell::Cell::new(1),
+                #ref_count_ident: ::core::cell::Cell::new(1),
                 #(#user_fields),*
             };
-            let instance = ::std::boxed::Box::pin(instance);
+            let instance = ::com::alloc::boxed::Box::pin(instance);
             ::com::production::ClassAllocation::new(instance)
         }
     }
@@ -59,7 +59,11 @@ fn gen_vpointer_inits(class: &Class) -> TokenStream {
             let interface = interface.to_initialized_vtable_tokens(class, index);
             let vptr_field_ident = quote::format_ident!("__{}", index);
             quote! {
-                let #vptr_field_ident = unsafe { ::std::ptr::NonNull::new_unchecked(::std::boxed::Box::into_raw(::std::boxed::Box::new(#interface))) };
+                let #vptr_field_ident = unsafe {
+                    ::core::ptr::NonNull::new_unchecked(
+                        ::com::alloc::boxed::Box::into_raw(::com::alloc::boxed::Box::new(#interface)),
+                    )
+                };
             }
         });
 

--- a/macros/support/src/class/class_factory.rs
+++ b/macros/support/src/class/class_factory.rs
@@ -11,7 +11,7 @@ pub fn generate(class: &Class) -> TokenStream {
     let class_name = &class.name;
     let user_fields = class.fields.iter().map(|f| {
         let ty = &f.ty;
-        quote! { <#ty as ::std::default::Default>::default() }
+        quote! { <#ty as ::core::default::Default>::default() }
     });
     quote! {
         ::com::class! {
@@ -21,12 +21,12 @@ pub fn generate(class: &Class) -> TokenStream {
             impl ::com::interfaces::IClassFactory for #class_factory_ident {
                 unsafe fn CreateInstance(
                     &self,
-                    aggr: *mut ::std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
+                    aggr: *mut ::core::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>,
                     riid: *const ::com::sys::IID,
-                    ppv: *mut *mut ::std::ffi::c_void,
+                    ppv: *mut *mut ::core::ffi::c_void,
                 ) -> ::com::sys::HRESULT {
                     assert!(!riid.is_null(), "iid passed to CreateInstance was null");
-                    if aggr != ::std::ptr::null_mut() {
+                    if aggr != ::core::ptr::null_mut() {
                         return ::com::sys::CLASS_E_NOAGGREGATION;
                     }
 

--- a/macros/support/src/class/iunknown_impl.rs
+++ b/macros/support/src/class/iunknown_impl.rs
@@ -47,7 +47,7 @@ impl IUnknownAbi {
             unsafe extern "stdcall" fn QueryInterface(
                 this: #this_ptr,
                 riid: *const ::com::sys::IID,
-                ppv: *mut *mut ::std::ffi::c_void
+                ppv: *mut *mut ::core::ffi::c_void
             ) -> ::com::sys::HRESULT {
                 #munge
                 munged.QueryInterface(riid, ppv)
@@ -70,7 +70,7 @@ impl IUnknownAbi {
 
         quote! {
             #owned
-            let munged = ::std::mem::ManuallyDrop::new(munged);
+            let munged = ::core::mem::ManuallyDrop::new(munged);
         }
     }
 }
@@ -85,7 +85,7 @@ impl IUnknown {
     pub fn to_add_ref_tokens(&self) -> TokenStream {
         let ref_count_ident = crate::utils::ref_count_ident();
         quote! {
-            pub unsafe fn AddRef(self: &::std::pin::Pin<::std::boxed::Box<Self>>) -> u32 {
+            pub unsafe fn AddRef(self: &::core::pin::Pin<::com::alloc::boxed::Box<Self>>) -> u32 {
                 let value = self.#ref_count_ident.get().checked_add(1).expect("Overflow of reference count");
                 self.#ref_count_ident.set(value);
                 value
@@ -99,18 +99,18 @@ impl IUnknown {
 
         quote! {
             pub unsafe fn QueryInterface(
-                self: &::std::pin::Pin<::std::boxed::Box<Self>>,
+                self: &::core::pin::Pin<::com::alloc::boxed::Box<Self>>,
                 riid: *const ::com::sys::IID,
-                ppv: *mut *mut ::std::ffi::c_void
+                ppv: *mut *mut ::core::ffi::c_void
             ) -> ::com::sys::HRESULT {
                 let riid = &*riid;
 
                 if riid == &::com::interfaces::iunknown::IID_IUNKNOWN {
                     // Cast the &Pin<Box<T>> as a pointer and then dereference
                     // it to get the Pin<Box> as a pointer
-                    *ppv = *(self as *const _ as *const *mut ::std::ffi::c_void);
+                    *ppv = *(self as *const _ as *const *mut ::core::ffi::c_void);
                 } #base_match_arms else {
-                    *ppv = ::std::ptr::null_mut::<::std::ffi::c_void>();
+                    *ppv = ::core::ptr::null_mut::<::core::ffi::c_void>();
                     return ::com::sys::E_NOINTERFACE;
                 }
 
@@ -129,7 +129,7 @@ impl IUnknown {
                 else if <#interface as ::com::Interface>::is_iid_in_inheritance_chain(riid) {
                     // Cast the &Pin<Box<T>> as a pointer and then dereference
                     // it to get the Pin<Box> as a pointer
-                    *ppv = (*(self as *const _ as *const *mut usize)).add(#index) as *mut ::std::ffi::c_void;
+                    *ppv = (*(self as *const _ as *const *mut usize)).add(#index) as *mut ::core::ffi::c_void;
                 }
             }
         });
@@ -140,6 +140,6 @@ impl IUnknown {
 
 fn this_ptr_type() -> TokenStream {
     quote! {
-        ::std::ptr::NonNull<::std::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>>
+        ::core::ptr::NonNull<::core::ptr::NonNull<<::com::interfaces::IUnknown as ::com::Interface>::VTable>>
     }
 }

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -26,7 +26,7 @@ impl Interface {
             #[repr(transparent)]
             #[derive(Debug)]
             #vis struct #name {
-                inner: ::std::ptr::NonNull<#vptr>,
+                inner: ::core::ptr::NonNull<#vptr>,
             }
             #impl_block
         }
@@ -67,10 +67,10 @@ impl Interface {
         let name = &self.name;
 
         quote! {
-            impl ::std::ops::Deref for #name {
+            impl ::core::ops::Deref for #name {
                 type Target = <#name as ::com::Interface>::Super;
                 fn deref(&self) -> &Self::Target {
-                    unsafe { ::std::mem::transmute(self) }
+                    unsafe { ::core::mem::transmute(self) }
                 }
             }
         }
@@ -92,7 +92,7 @@ impl Interface {
         let name = &self.name;
 
         quote! {
-            impl ::std::clone::Clone for #name {
+            impl ::core::clone::Clone for #name {
                 fn clone(&self) -> Self {
                     unsafe {
                         <Self as ::com::Interface>::as_iunknown(self).AddRef();
@@ -300,7 +300,7 @@ impl InterfaceMethod {
             } else {
                 let generic = quote::format_ident!("__{}", index);
                 args.push(quote! { #pat: #generic });
-                generics.push(quote! { #generic: ::std::convert::Into<::com::Param<'a, #ty>> });
+                generics.push(quote! { #generic: ::core::convert::Into<::com::Param<'a, #ty>> });
 
                 // note: we separate the call to `into` and `get_abi` so that the `param`
                 // binding lives to the end of the method.

--- a/macros/support/src/interface/mod.rs
+++ b/macros/support/src/interface/mod.rs
@@ -37,22 +37,22 @@ fn convert_impls(parents: HashMap<Ident, Path>) -> Vec<TokenStream> {
         let mut current = &name;
         while let Some(p) = parents.get(current) {
             result.push(quote::quote! {
-                impl ::std::convert::From<#name> for #p {
+                impl ::core::convert::From<#name> for #p {
                     fn from(this: #name) -> Self {
-                        unsafe { ::std::mem::transmute(this) }
+                        unsafe { ::core::mem::transmute(this) }
                     }
                 }
-                impl <'a> ::std::convert::From<&'a #name> for &'a #p {
+                impl <'a> ::core::convert::From<&'a #name> for &'a #p {
                     fn from(this: &'a #name) -> Self {
-                        unsafe { ::std::mem::transmute(this) }
+                        unsafe { ::core::mem::transmute(this) }
                     }
                 }
-                impl <'a> ::std::convert::Into<::com::Param<'a, #p>> for #name {
+                impl <'a> ::core::convert::Into<::com::Param<'a, #p>> for #name {
                     fn into(self) -> ::com::Param<'a, #p> {
                         ::com::Param::Owned(self.into())
                     }
                 }
-                impl <'a> ::std::convert::Into<::com::Param<'a, #p>> for &'a #name {
+                impl <'a> ::core::convert::Into<::com::Param<'a, #p>> for &'a #name {
                     fn into(self) -> ::com::Param<'a, #p> {
                         ::com::Param::Borrowed(self.into())
                     }

--- a/macros/support/src/interface/vptr.rs
+++ b/macros/support/src/interface/vptr.rs
@@ -10,7 +10,7 @@ pub fn generate(interface: &Interface) -> TokenStream {
 
     quote!(
         #[allow(missing_docs)]
-        #vis type #vptr_ident = ::std::ptr::NonNull<#vtable_ident>;
+        #vis type #vptr_ident = ::core::ptr::NonNull<#vtable_ident>;
     )
 }
 

--- a/macros/support/src/interface/vtable.rs
+++ b/macros/support/src/interface/vtable.rs
@@ -73,7 +73,7 @@ fn gen_vtable_function_signature(
 fn gen_raw_params(interface_ident: &Ident, method: &InterfaceMethod) -> syn::Result<TokenStream> {
     let vptr_ident = vptr::ident(&interface_ident);
     let mut params = vec![quote!(
-        ::std::ptr::NonNull<#vptr_ident>,
+        ::core::ptr::NonNull<#vptr_ident>,
     )];
 
     for param in method.args.iter() {

--- a/src/abi_transferable.rs
+++ b/src/abi_transferable.rs
@@ -19,7 +19,7 @@ pub unsafe trait AbiTransferable: Sized {
     fn from_abi(abi: Self::Abi) -> Self {
         // This must be safe for the implementing type to
         // correctly implement this trait.
-        unsafe { std::mem::transmute_copy(&abi) }
+        unsafe { core::mem::transmute_copy(&abi) }
     }
 
     /// Convert a pointer to a `Self::Abi` and and a length to a slice.
@@ -29,7 +29,7 @@ pub unsafe trait AbiTransferable: Sized {
     /// `len` size for the lifetime `'a`. Nothing can mutate that array while
     /// the slice exists.
     unsafe fn slice_from_abi<'a>(abi: *const Self::Abi, len: usize) -> &'a [Self] {
-        std::slice::from_raw_parts(std::mem::transmute_copy(&abi), len)
+        core::slice::from_raw_parts(core::mem::transmute_copy(&abi), len)
     }
 
     /// Convert a pointer to a `Self::Abi` and and a length to a mutable slice.
@@ -38,15 +38,15 @@ pub unsafe trait AbiTransferable: Sized {
     /// The same rules apply as with `slice_from_abi` but no other references into
     /// the slice are allowed while the slice exists.
     unsafe fn slice_from_mut_abi<'a>(abi: *mut Self::Abi, len: usize) -> &'a mut [Self] {
-        std::slice::from_raw_parts_mut(std::mem::transmute_copy(&abi), len)
+        core::slice::from_raw_parts_mut(core::mem::transmute_copy(&abi), len)
     }
 
     /// Converts and consumes the ABI transferable type into its ABI representation.
     fn into_abi(self) -> Self::Abi {
         // This must be safe for the implementing type to
         // correctly implement this trait.
-        let abi = unsafe { std::mem::transmute_copy(&self) };
-        std::mem::forget(self);
+        let abi = unsafe { core::mem::transmute_copy(&self) };
+        core::mem::forget(self);
         abi
     }
 }
@@ -101,7 +101,7 @@ unsafe impl<T> AbiTransferable for *const T {
 }
 
 unsafe impl<T: crate::Interface> AbiTransferable for T {
-    type Abi = std::ptr::NonNull<std::ptr::NonNull<<T as crate::Interface>::VTable>>;
+    type Abi = core::ptr::NonNull<core::ptr::NonNull<<T as crate::Interface>::VTable>>;
     fn get_abi(&self) -> Self::Abi {
         self.as_raw()
     }
@@ -112,17 +112,17 @@ unsafe impl<T: crate::Interface> AbiTransferable for T {
 }
 
 unsafe impl<T: crate::Interface> AbiTransferable for Option<T> {
-    type Abi = *mut std::ptr::NonNull<<T as crate::Interface>::VTable>;
+    type Abi = *mut core::ptr::NonNull<<T as crate::Interface>::VTable>;
     fn get_abi(&self) -> Self::Abi {
         self.as_ref()
             .map(|p| p.as_raw().as_ptr())
-            .unwrap_or(::std::ptr::null_mut())
+            .unwrap_or(::core::ptr::null_mut())
     }
 
     fn set_abi(&mut self) -> *mut Self::Abi {
         &mut self
             .as_mut()
             .map(|p| p.as_raw().as_ptr())
-            .unwrap_or(::std::ptr::null_mut())
+            .unwrap_or(::core::ptr::null_mut())
     }
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -31,14 +31,14 @@ pub unsafe trait Interface: Sized + 'static {
 
     /// Cast the interface pointer to a pointer to IUnknown.
     fn as_iunknown(&self) -> &IUnknown {
-        unsafe { std::mem::transmute(self) }
+        unsafe { core::mem::transmute(self) }
     }
 
     /// Cast the COM interface pointer to a raw pointer
     ///
     /// The returned pointer is only guranteed valid for as long
     /// as the reference to self id valid.
-    fn as_raw(&self) -> std::ptr::NonNull<std::ptr::NonNull<Self::VTable>> {
-        unsafe { std::mem::transmute_copy(self) }
+    fn as_raw(&self) -> core::ptr::NonNull<core::ptr::NonNull<Self::VTable>> {
+        unsafe { core::mem::transmute_copy(self) }
     }
 }

--- a/src/interfaces/iclass_factory.rs
+++ b/src/interfaces/iclass_factory.rs
@@ -1,7 +1,7 @@
 //! Everything related to the [IClassFactory](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iclassfactory) COM interface
 use crate::interfaces;
 use crate::sys::{BOOL, FAILED, GUID, HRESULT};
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 use crate::{interfaces::iunknown::IUnknown, Interface};
 

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -4,7 +4,7 @@ use crate::sys::{E_NOINTERFACE, E_POINTER, FAILED};
 use crate::sys::{GUID, HRESULT};
 use crate::{interfaces, Interface, IID};
 
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 interfaces! {
     /// [IUnknown](https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown) COM interface
@@ -23,16 +23,15 @@ interfaces! {
         /// The COM [`AddRef` Method]
         ///
         /// This method normally should not be called directly. This method is used by
-        /// [`ComPtr`] to implement the reference counting mechanism.
+        /// the `Clone` implementation of interfaces to implement the reference counting mechanism.
         ///
         /// [`AddRef` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-addref
-        /// [`ComPtr`]: struct.ComPtr.html
         pub unsafe fn AddRef(&self) -> u32;
 
         /// The COM [`Release` Method]
         ///
         /// This method normally should not be called directly. This method is used by
-        /// [`ComPtr`] to implement the reference counting mechanism.
+        /// the `Drop` implementation of interfaces to implement the reference counting mechanism.
         ///
         /// [`Release` Method]: https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-release
         /// [`ComPtr`]: struct.ComPtr.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //! See the examples directory in the repository for more examples.
 //!
 
+#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![deny(missing_docs)]
 
 mod abi_transferable;
@@ -113,3 +114,8 @@ pub use com_macros::class;
 // whether they are used by some other crate or internally
 #[doc(hidden)]
 extern crate self as com;
+
+// We re-export `alloc` so that we can use `com::alloc::boxed::Box` in generated code,
+// for code that uses `#![no_std]`.
+#[doc(hidden)]
+pub extern crate alloc;

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -1,14 +1,15 @@
 //! Helpers for registering COM servers
 
+use crate::alloc::{format, string::String, vec::Vec};
 use crate::sys::{
     GetModuleFileNameA, RegCloseKey, RegCreateKeyExA, RegDeleteKeyA, RegSetValueExA, CLSID,
     ERROR_SUCCESS, FAILED, HKEY, HRESULT, LSTATUS, SELFREG_E_CLASS, S_OK,
 };
-
-use std::convert::TryInto;
-use std::ffi::c_void;
+extern crate std;
+use core::convert::TryInto;
+use core::ffi::c_void;
+use core::str;
 use std::ffi::CString;
-use std::str;
 
 #[doc(hidden)]
 pub struct RegistryKeyInfo {
@@ -57,10 +58,10 @@ const HKEY_CLASSES_ROOT: HKEY = 0x8000_0000 as HKEY;
 const KEY_ALL_ACCESS: u32 = 0x000F_003F;
 const REG_OPTION_NON_VOLATILE: u32 = 0x00000000;
 fn create_class_key(key_info: &RegistryKeyInfo) -> Result<HKEY, LSTATUS> {
-    let mut hk_result = std::ptr::null_mut::<c_void>();
-    let lp_class = std::ptr::null_mut::<u8>();
-    let lp_security_attributes = std::ptr::null_mut::<c_void>();
-    let lpdw_disposition = std::ptr::null_mut::<u32>();
+    let mut hk_result = core::ptr::null_mut::<c_void>();
+    let lp_class = core::ptr::null_mut::<u8>();
+    let lp_security_attributes = core::ptr::null_mut::<c_void>();
+    let lpdw_disposition = core::ptr::null_mut::<u32>();
     let result = unsafe {
         RegCreateKeyExA(
             HKEY_CLASSES_ROOT,
@@ -175,9 +176,9 @@ pub fn dll_unregister_server(relevant_keys: &mut Vec<RegistryKeyInfo>) -> HRESUL
 #[macro_export]
 macro_rules! inproc_dll_module {
     (($class_id_one:ident, $class_type_one:ty), $(($class_id:ident, $class_type:ty)),*) => {
-        static mut _HMODULE: *mut ::std::ffi::c_void = ::std::ptr::null_mut();
+        static mut _HMODULE: *mut ::core::ffi::c_void = ::core::ptr::null_mut();
         #[no_mangle]
-        unsafe extern "stdcall" fn DllMain(hinstance: *mut ::std::ffi::c_void, fdw_reason: u32, reserved: *mut ::std::ffi::c_void) -> i32 {
+        unsafe extern "stdcall" fn DllMain(hinstance: *mut ::core::ffi::c_void, fdw_reason: u32, reserved: *mut ::core::ffi::c_void) -> i32 {
             const DLL_PROCESS_ATTACH: u32 = 1;
             if fdw_reason == DLL_PROCESS_ATTACH {
                 unsafe { _HMODULE = hinstance; }
@@ -186,7 +187,7 @@ macro_rules! inproc_dll_module {
         }
 
         #[no_mangle]
-        unsafe extern "stdcall" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::std::ffi::c_void) -> ::com::sys::HRESULT {
+        unsafe extern "stdcall" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::core::ffi::c_void) -> ::com::sys::HRESULT {
             use ::com::interfaces::IUnknown;
             assert!(!class_id.is_null(), "class id passed to DllGetClassObject should never be null");
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::sys::{
     CLSCTX_INPROC_SERVER, CLSID, COINIT_APARTMENTTHREADED, COINIT_MULTITHREADED, FAILED, HRESULT,
     IID, S_FALSE, S_OK,
 };
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 use crate::Interface;
 
@@ -18,7 +18,7 @@ use crate::Interface;
 ///
 /// This function only needs to be called once per process.
 pub fn init_runtime() -> Result<(), HRESULT> {
-    let mut _cookie = std::ptr::null_mut::<c_void>();
+    let mut _cookie = core::ptr::null_mut::<c_void>();
     match unsafe { CoIncrementMTAUsage(&mut _cookie as *mut _ as *mut _) } {
         // S_OK indicates the runtime was initialized
         S_OK => Ok(()),
@@ -50,7 +50,7 @@ pub enum ApartmentType {
 // with a specific apartment type.
 // TODO: add helpers for establishing a message pump
 pub fn init_apartment(apartment_type: ApartmentType) -> Result<(), HRESULT> {
-    match unsafe { CoInitializeEx(std::ptr::null_mut::<c_void>(), apartment_type as u32) } {
+    match unsafe { CoInitializeEx(core::ptr::null_mut::<c_void>(), apartment_type as u32) } {
         // S_OK indicates the runtime was initialized
         S_OK | S_FALSE => Ok(()),
         // Any other result is considered an error here.
@@ -81,7 +81,7 @@ impl ApartmentRuntime {
     pub fn new(apartment_type: ApartmentType) -> Result<Self, HRESULT> {
         init_apartment(apartment_type)?;
         Ok(Self {
-            _priv: std::ptr::null(),
+            _priv: core::ptr::null(),
         })
     }
 }
@@ -101,7 +101,7 @@ pub fn get_class_object<T: Interface>(class_id: &CLSID) -> Result<T, HRESULT> {
         CoGetClassObject(
             class_id as *const CLSID,
             CLSCTX_INPROC_SERVER,
-            std::ptr::null_mut::<c_void>(),
+            core::ptr::null_mut::<c_void>(),
             &T::IID as *const IID,
             &mut class as *mut _ as _,
         )
@@ -117,7 +117,7 @@ pub fn get_class_object<T: Interface>(class_id: &CLSID) -> Result<T, HRESULT> {
 ///
 /// Calls `CoCreateInstance` internally
 pub fn create_instance<T: Interface>(class_id: &CLSID) -> Result<T, HRESULT> {
-    unsafe { Ok(create_raw_instance::<T>(class_id, std::ptr::null_mut())?) }
+    unsafe { Ok(create_raw_instance::<T>(class_id, core::ptr::null_mut())?) }
 }
 
 /// A helper for creating both regular and aggregated instances

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,5 +1,5 @@
 //! Types for interacting with COM related system APIs
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 /// A Windows result code
 pub type HRESULT = i32;
@@ -64,8 +64,8 @@ pub type IID = GUID;
 /// A class ID
 pub type CLSID = GUID;
 
-impl std::fmt::Debug for GUID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for GUID {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
             "{:08X}-{:04X}-{:04X}-{:02X}{:02X}-{:02X}{:02X}{:02X}{:02X}{:02X}{:02X}",
@@ -83,8 +83,8 @@ impl std::fmt::Debug for GUID {
         )
     }
 }
-impl std::fmt::Display for GUID {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for GUID {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
     }
 }


### PR DESCRIPTION
This changes the generated code so that it uses the core crate
(where applicable) instead of the std crate. Almost everything in the
generated code can directly use core, with the only exceptions being
allocation container types, like Box. These are changed to use
`alloc::boxed::Box`.

This allows the generated code to work in crates that are using
`#![no_std]`. I've also added a very simple example crate that
demonstrates using `com-rs` with `#![no_std]`.

Also, I edited the doc comments for `IUnknown::AddRef` and
`IUnknown::Release`. They contained references to a ComPtr type, which
no longer exists.