### PR TITLE
Compatiblity with Windows API

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Short explanation: This generates the VTable layout for IUnknown and IAnimal as 
 Interaction with COM components are always through an Interface Pointer (a pointer to a pointer to a VTable). 
 
 ```rust
-use com::run_time::{create_instance, init_runtime};
+use com::runtime::{create_instance, init_runtime};
 
 // Initialises the COM library
 init_runtime().expect("Failed to initialize COM Library");

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -95,7 +95,7 @@ class! {
     // are specified between `()` after their child interface. If no parent is specified for an 
     // interface, it is assumed to be `IUnknown`. Multiple interface hierarchies can be specified
     // each separated by a comma.
-    pub class MyCass: ISomeInterface(ISomeParentInterface(ISomeGrandparentInterface)) {
+    pub class MyClass: ISomeInterface(ISomeParentInterface(ISomeGrandparentInterface)) {
         // You can have as many inner fields as you want.
         inner_field: std::cell::Cell<usize>,
     }

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -59,7 +59,7 @@ impl std::ops::Deref for IAnimal {
     }
 }
 
-// On drop the interface will call the IUknown::Release method
+// On drop the interface will call the IUnknown::Release method
 impl Drop for IAnimal {
     fn drop(&mut self) {
         // This is safe because we are calling `Release` when the interface handle is no

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -428,9 +428,9 @@ impl Interface {
                 #release
                 #query_interface
                 IUnknownVTable {
+                    QueryInterface,
                     AddRef,
                     Release,
-                    QueryInterface,
                 }
             }
         }

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -423,11 +423,11 @@ impl Interface {
         let query_interface = iunknown.to_query_interface_tokens();
         quote! {
             {
-                type IUknownVTable = <::com::interfaces::IUnknown as ::com::Interface>::VTable;
+                type IUnknownVTable = <::com::interfaces::IUnknown as ::com::Interface>::VTable;
                 #add_ref
                 #release
                 #query_interface
-                IUknownVTable {
+                IUnknownVTable {
                     AddRef,
                     Release,
                     QueryInterface,

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -431,11 +431,11 @@ impl Interface {
                 #add_ref
                 #release
                 #query_interface
-                IUnknownVTable {
+                ::std::mem::transmute(IUnknownVTable {
                     QueryInterface,
                     AddRef,
                     Release,
-                }
+                })
             }
         }
     }

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -417,7 +417,11 @@ impl Interface {
     }
 
     fn iunknown_tokens(class: &Class, offset: usize) -> TokenStream {
-        let iunknown = super::iunknown_impl::IUnknownAbi::new(class.name.clone(), offset);
+        let iunknown = super::iunknown_impl::IUnknownAbi::new(
+            class.name.clone(),
+            offset,
+            quote! { IUnknownVTable },
+        );
         let add_ref = iunknown.to_add_ref_tokens();
         let release = iunknown.to_release_tokens();
         let query_interface = iunknown.to_query_interface_tokens();

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,4 +1,4 @@
-//! Common COM interfaces including IUknown and IClassFactory
+//! Common COM interfaces including IUnknown and IClassFactory
 
 pub mod iclass_factory;
 pub mod iunknown;


### PR DESCRIPTION
As I've discussed in #196 , I am beginning to work on getting this package to be compatible with interfaces defined in the `windows` and `winapi` crates. Until we decide what's the correct API change, I'm going to push my non API breaking changes here and leave the heavier stuff in my local code.

TODO:
- [x] Stop statically relying on the IUnknown vtable being the com-rs defined one
- [x] Check what else we need to get `com::class!` to work
- [ ] Integrate with the interface definitions in `windows` crate
