### PR TITLE
Use extern "system" instead of extern "stdcall"

### DIFF
--- a/docs/safety.md
+++ b/docs/safety.md
@@ -88,7 +88,7 @@ impl ::core::clone::Clone for IAnimal {
 #[repr(C)]
 pub struct IAnimalVTable {
     pub iunknown_base: <IUnknown as com::Interface>::VTable,
-    pub Eat: unsafe extern "stdcall" fn(std::ptr::NonNull<IAnimalVPtr>) -> HRESULT,
+    pub Eat: unsafe extern "system" fn(std::ptr::NonNull<IAnimalVPtr>) -> HRESULT,
 }
 
 pub type IAnimalVPtr = std::ptr::NonNull<IAnimalVTable>;

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -386,7 +386,7 @@ impl Interface {
             let ret = &m.sig.output;
             let method = quote! {
                 #[allow(non_snake_case)]
-                unsafe extern "stdcall" fn #name(this: ::core::ptr::NonNull<::core::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
+                unsafe extern "system" fn #name(this: ::core::ptr::NonNull<::core::ptr::NonNull<#vtable_ident>>, #(#params),*) #ret {
                     let this = this.as_ptr().sub(#offset);
                     let this = ::core::mem::ManuallyDrop::new(::com::production::ClassAllocation::from_raw(this as *mut _ as *mut #class_name));
                     #(#translation)*

--- a/macros/support/src/class/iunknown_impl.rs
+++ b/macros/support/src/class/iunknown_impl.rs
@@ -19,7 +19,7 @@ impl IUnknownAbi {
         let munge = self.borrowed_pointer_munging();
 
         quote! {
-            unsafe extern "stdcall" fn AddRef(this: #this_ptr) -> u32 {
+            unsafe extern "system" fn AddRef(this: #this_ptr) -> u32 {
                 #munge
                 munged.AddRef()
             }
@@ -32,7 +32,7 @@ impl IUnknownAbi {
         let ref_count_ident = crate::utils::ref_count_ident();
 
         quote! {
-            unsafe extern "stdcall" fn Release(this: #this_ptr) -> u32 {
+            unsafe extern "system" fn Release(this: #this_ptr) -> u32 {
                 #munge
                 munged.#ref_count_ident.get().checked_sub(1).expect("Underflow of reference count")
             }
@@ -44,7 +44,7 @@ impl IUnknownAbi {
         let munge = self.borrowed_pointer_munging();
 
         quote! {
-            unsafe extern "stdcall" fn QueryInterface(
+            unsafe extern "system" fn QueryInterface(
                 this: #this_ptr,
                 riid: *const ::com::sys::IID,
                 ppv: *mut *mut ::core::ffi::c_void

--- a/macros/support/src/interface/vtable.rs
+++ b/macros/support/src/interface/vtable.rs
@@ -66,7 +66,7 @@ fn gen_vtable_function_signature(
     let return_type = &method.ret;
 
     Ok(quote!(
-        unsafe extern "stdcall" fn(#params) #return_type
+        unsafe extern "system" fn(#params) #return_type
     ))
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -8,7 +8,7 @@ use crate::sys::IID;
 /// The struct implementing this trait must provide a valid vtable as the
 /// associated VTable type. A vtable is valid if:
 /// * it is `#[repr(C)]`
-/// * the type only contains `extern "stdcall" fn" definitions
+/// * the type only contains `extern "system" fn" definitions
 ///
 /// The implementor must be a transparrently equivalent to a valid interface pointer
 /// for the interface `T`. An interface pointer as the name suggests points to an

--- a/src/production/registration.rs
+++ b/src/production/registration.rs
@@ -178,7 +178,7 @@ macro_rules! inproc_dll_module {
     (($class_id_one:ident, $class_type_one:ty), $(($class_id:ident, $class_type:ty)),*) => {
         static mut _HMODULE: *mut ::core::ffi::c_void = ::core::ptr::null_mut();
         #[no_mangle]
-        unsafe extern "stdcall" fn DllMain(hinstance: *mut ::core::ffi::c_void, fdw_reason: u32, reserved: *mut ::core::ffi::c_void) -> i32 {
+        unsafe extern "system" fn DllMain(hinstance: *mut ::core::ffi::c_void, fdw_reason: u32, reserved: *mut ::core::ffi::c_void) -> i32 {
             const DLL_PROCESS_ATTACH: u32 = 1;
             if fdw_reason == DLL_PROCESS_ATTACH {
                 unsafe { _HMODULE = hinstance; }
@@ -187,7 +187,7 @@ macro_rules! inproc_dll_module {
         }
 
         #[no_mangle]
-        unsafe extern "stdcall" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::core::ffi::c_void) -> ::com::sys::HRESULT {
+        unsafe extern "system" fn DllGetClassObject(class_id: *const ::com::sys::CLSID, iid: *const ::com::sys::IID, result: *mut *mut ::core::ffi::c_void) -> ::com::sys::HRESULT {
             use ::com::interfaces::IUnknown;
             assert!(!class_id.is_null(), "class id passed to DllGetClassObject should never be null");
 
@@ -204,12 +204,12 @@ macro_rules! inproc_dll_module {
         }
 
         #[no_mangle]
-        extern "stdcall" fn DllRegisterServer() -> ::com::sys::HRESULT {
+        extern "system" fn DllRegisterServer() -> ::com::sys::HRESULT {
             ::com::production::registration::dll_register_server(&mut get_relevant_registry_keys())
         }
 
         #[no_mangle]
-        extern "stdcall" fn DllUnregisterServer() -> ::com::sys::HRESULT {
+        extern "system" fn DllUnregisterServer() -> ::com::sys::HRESULT {
             ::com::production::registration::dll_unregister_server(&mut get_relevant_registry_keys())
         }
 


### PR DESCRIPTION
This allows com-rs to compile on non-Windows platforms. Specifically,
when compiling on aarch64-linux-android, Rust rejects this because
the "stdcall" calling convention is unsupported.  The "system" calling
convention is an alias for "stdcall" on Windows, and is just "use the
normal calling convention" on all other platforms.