### PR TITLE
Compatiblity with the Windows crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "./README.md"
 
 [dependencies]
 com_macros = { version = "0.4", path = "macros" }
+const-sha1 = "0.2"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Short explanation: This generates the VTable layout for IUnknown and IAnimal as 
 Interaction with COM components are always through an Interface Pointer (a pointer to a pointer to a VTable). 
 
 ```rust
-use com::run_time::{create_instance, init_runtime};
+use com::runtime::{create_instance, init_runtime};
 
 // Initialises the COM library
 init_runtime().expect("Failed to initialize COM Library");

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -95,7 +95,7 @@ class! {
     // are specified between `()` after their child interface. If no parent is specified for an 
     // interface, it is assumed to be `IUnknown`. Multiple interface hierarchies can be specified
     // each separated by a comma.
-    pub class MyCass: ISomeInterface(ISomeParentInterface(ISomeGrandparentInterface)) {
+    pub class MyClass: ISomeInterface(ISomeParentInterface(ISomeGrandparentInterface)) {
         // You can have as many inner fields as you want.
         inner_field: std::cell::Cell<usize>,
     }

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -44,8 +44,7 @@ impl IAnimal {
     // This is likely to be the case as interface automatically keeps 
     // track of its reference count.
     pub unsafe fn Eat(&self) -> HRESULT {
-        let interface_ptr = <Self as com::AbiTransferable>::get_abi(self);
-        (interface_ptr.as_ref().as_ref().Eat)(interface_ptr)
+        (self.inner.as_ref().as_ref().Eat)(self.inner)
     }
 }
 

--- a/docs/safety.md
+++ b/docs/safety.md
@@ -59,7 +59,7 @@ impl std::ops::Deref for IAnimal {
     }
 }
 
-// On drop the interface will call the IUknown::Release method
+// On drop the interface will call the IUnknown::Release method
 impl Drop for IAnimal {
     fn drop(&mut self) {
         // This is safe because we are calling `Release` when the interface handle is no

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -428,9 +428,9 @@ impl Interface {
                 #release
                 #query_interface
                 IUnknownVTable {
+                    QueryInterface,
                     AddRef,
                     Release,
-                    QueryInterface,
                 }
             }
         }

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -423,11 +423,11 @@ impl Interface {
         let query_interface = iunknown.to_query_interface_tokens();
         quote! {
             {
-                type IUknownVTable = <::com::interfaces::IUnknown as ::com::Interface>::VTable;
+                type IUnknownVTable = <::com::interfaces::IUnknown as ::com::Interface>::VTable;
                 #add_ref
                 #release
                 #query_interface
-                IUknownVTable {
+                IUnknownVTable {
                     AddRef,
                     Release,
                     QueryInterface,

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -431,11 +431,11 @@ impl Interface {
                 #add_ref
                 #release
                 #query_interface
-                IUnknownVTable {
+                ::std::mem::transmute(IUnknownVTable {
                     QueryInterface,
                     AddRef,
                     Release,
-                }
+                })
             }
         }
     }

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -417,7 +417,11 @@ impl Interface {
     }
 
     fn iunknown_tokens(class: &Class, offset: usize) -> TokenStream {
-        let iunknown = super::iunknown_impl::IUnknownAbi::new(class.name.clone(), offset);
+        let iunknown = super::iunknown_impl::IUnknownAbi::new(
+            class.name.clone(),
+            offset,
+            quote! { IUnknownVTable },
+        );
         let add_ref = iunknown.to_add_ref_tokens();
         let release = iunknown.to_release_tokens();
         let query_interface = iunknown.to_query_interface_tokens();

--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -280,7 +280,6 @@ impl InterfaceMethod {
     fn to_tokens(&self) -> TokenStream {
         let inner_method_ident =
             format_ident!("{}", crate::utils::snake_to_camel(&self.name.to_string()));
-        let interface_ptr_ident = format_ident!("interface_ptr");
 
         let outer_method_ident = &self.name;
         let return_type = &self.ret;
@@ -289,7 +288,7 @@ impl InterfaceMethod {
         if !self.args.is_empty() {
             generics.push(quote! { 'a })
         }
-        let mut params = vec![quote!(#interface_ptr_ident)];
+        let mut params = vec![quote! { self.inner }];
         let mut args = Vec::new();
         let mut into = Vec::new();
         for (index, arg) in self.args.iter().enumerate() {
@@ -319,8 +318,7 @@ impl InterfaceMethod {
             #(#docs)*
             #vis unsafe fn #outer_method_ident<#(#generics),*>(&self, #(#args),*) #return_type {
                 #(#into)*
-                let #interface_ptr_ident = <Self as ::com::AbiTransferable>::get_abi(self);
-                (#interface_ptr_ident.as_ref().as_ref().#inner_method_ident)(#(#params),*)
+                (self.inner.as_ref().as_ref().#inner_method_ident)(#(#params),*)
             }
         };
     }

--- a/src/interfaces/iunknown.rs
+++ b/src/interfaces/iunknown.rs
@@ -65,3 +65,16 @@ impl IUnknown {
         ppv
     }
 }
+
+impl PartialEq for IUnknown {
+    fn eq(&self, other: &Self) -> bool {
+        // Since COM objects may implement multiple intefaces, COM identity can only
+        // be determined by querying for `IUnknown` explicitly and then comparing the
+        // pointer values. This works since `QueryInterface` is required to return
+        // the same pointer value for queries for `IUnknown`.
+        self.cast::<IUnknown>().unwrap().inner == other.cast::<IUnknown>().unwrap().inner
+    }
+}
+
+impl Eq for IUnknown {}
+

--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -1,4 +1,4 @@
-//! Common COM interfaces including IUknown and IClassFactory
+//! Common COM interfaces including IUnknown and IClassFactory
 
 pub mod iclass_factory;
 pub mod iunknown;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,7 @@
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 #![deny(missing_docs)]
 
-mod abi_transferable;
-mod interface;
+mod traits;
 pub mod interfaces;
 mod param;
 #[cfg(windows)]
@@ -59,9 +58,9 @@ pub mod sys;
 pub mod production;
 
 #[doc(inline)]
-pub use abi_transferable::AbiTransferable;
+pub use traits::AbiTransferable;
 #[doc(inline)]
-pub use interface::Interface;
+pub use traits::Interface;
 #[doc(inline)]
 pub use param::Param;
 #[doc(inline)]

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -17,6 +17,12 @@ pub type LSTATUS = i32;
 /// HKEY type
 pub type HKEY = *mut c_void;
 
+#[doc(hidden)]
+pub type RawPtr = *mut std::ffi::c_void;
+
+#[doc(hidden)]
+pub use const_sha1::ConstBuffer;
+
 /// No error
 pub const S_OK: HRESULT = 0;
 /// No error
@@ -83,9 +89,121 @@ impl core::fmt::Debug for GUID {
         )
     }
 }
+
 impl core::fmt::Display for GUID {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
+    }
+}
+
+#[doc(hidden)]
+pub trait HexReader {
+    fn next_u8(&mut self) -> u8;
+    fn next_u16(&mut self) -> u16;
+    fn next_u32(&mut self) -> u32;
+}
+
+impl HexReader for std::str::Bytes<'_> {
+    fn next_u8(&mut self) -> u8 {
+        let value = self.next().unwrap();
+        match value {
+            b'0'..=b'9' => value - b'0',
+            b'A'..=b'F' => 10 + value - b'A',
+            b'a'..=b'f' => 10 + value - b'a',
+            _ => panic!("Invalid GUID string"),
+        }
+    }
+
+    fn next_u16(&mut self) -> u16 {
+        self.next_u8().into()
+    }
+
+    fn next_u32(&mut self) -> u32 {
+        self.next_u8().into()
+    }
+}
+
+
+impl From<&str> for GUID {
+    fn from(value: &str) -> GUID {
+        assert!(value.len() == 36, "Invalid GUID string");
+        let mut bytes = value.bytes();
+
+        let a = ((bytes.next_u32() * 16 + bytes.next_u32()) << 24)
+            + ((bytes.next_u32() * 16 + bytes.next_u32()) << 16)
+            + ((bytes.next_u32() * 16 + bytes.next_u32()) << 8)
+            + bytes.next_u32() * 16
+            + bytes.next_u32();
+        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
+        let b = ((bytes.next_u16() * 16 + (bytes.next_u16())) << 8)
+            + bytes.next_u16() * 16
+            + bytes.next_u16();
+        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
+        let c = ((bytes.next_u16() * 16 + bytes.next_u16()) << 8)
+            + bytes.next_u16() * 16
+            + bytes.next_u16();
+        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
+        let d = bytes.next_u8() * 16 + bytes.next_u8();
+        let e = bytes.next_u8() * 16 + bytes.next_u8();
+        assert!(bytes.next().unwrap() == b'-', "Invalid GUID string");
+
+        let f = bytes.next_u8() * 16 + bytes.next_u8();
+        let g = bytes.next_u8() * 16 + bytes.next_u8();
+        let h = bytes.next_u8() * 16 + bytes.next_u8();
+        let i = bytes.next_u8() * 16 + bytes.next_u8();
+        let j = bytes.next_u8() * 16 + bytes.next_u8();
+        let k = bytes.next_u8() * 16 + bytes.next_u8();
+
+        GUID::from_values(a, b, c, [d, e, f, g, h, i, j, k])
+    }
+}
+
+impl GUID {
+    /// Creates a `GUID` represented by the all-zero byte-pattern.
+    pub const fn zeroed() -> GUID {
+        GUID {
+            data1: 0,
+            data2: 0,
+            data3: 0,
+            data4: [0, 0, 0, 0, 0, 0, 0, 0],
+        }
+    }
+
+    /// Creates a `GUID` with the given constant values.
+    pub const fn from_values(data1: u32, data2: u16, data3: u16, data4: [u8; 8]) -> GUID {
+        GUID {
+            data1,
+            data2,
+            data3,
+            data4,
+        }
+    }
+
+    /// Creates a `GUID` for a "generic" WinRT type.
+    pub const fn from_signature(signature: ConstBuffer) -> GUID {
+        let data = ConstBuffer::from_slice(&[
+            0x11, 0xf4, 0x7a, 0xd5, 0x7b, 0x73, 0x42, 0xc0, 0xab, 0xae, 0x87, 0x8b, 0x1e, 0x16,
+            0xad, 0xee,
+        ]);
+
+        let data = data.push_other(signature);
+
+        let bytes = const_sha1::sha1(&data).bytes();
+        let first = u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+
+        let second = u16::from_be_bytes([bytes[4], bytes[5]]);
+        let mut third = u16::from_be_bytes([bytes[6], bytes[7]]);
+        third = (third & 0x0fff) | (5 << 12);
+        let fourth = (bytes[8] & 0x3f) | 0x80;
+
+        Self::from_values(
+            first,
+            second,
+            third,
+            [
+                fourth, bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+            ],
+        )
     }
 }
 

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -1,5 +1,6 @@
 use crate::interfaces::IUnknown;
 use crate::sys::IID;
+use crate::sys::RawPtr;
 
 /// A COM compliant interface pointer
 ///
@@ -40,5 +41,24 @@ pub unsafe trait Interface: Sized + 'static {
     /// as the reference to self id valid.
     fn as_raw(&self) -> core::ptr::NonNull<core::ptr::NonNull<Self::VTable>> {
         unsafe { core::mem::transmute_copy(self) }
+    }
+
+    /// Returns the vtable for the current interface.
+    unsafe fn vtable(&self) -> &Self::VTable {
+        self.assume_vtable::<Self>()
+    }
+
+    /// Returns the vtable for an assumed interface. The name comes from `Box`'s `assume_init` method as
+    /// it assumes the vtable is implemented by the current interface's vtable (e.g. a parent interface).
+    unsafe fn assume_vtable<T: Interface>(&self) -> &T::VTable {
+        let this: RawPtr = std::mem::transmute_copy(self);
+        &(*(*(this as *mut *mut _) as *mut _))
+    }
+
+    /// Attempts to cast the current interface to another interface using `QueryInterface`.
+    /// The name `cast` is preferred to `query` because there is a WinRT method named query but not one
+    /// named cast.
+    fn cast<T: Interface>(&self) -> Option<T> {
+        self.as_iunknown().query_interface::<T>()
     }
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,0 +1,5 @@
+mod abi_transferable;
+mod interface;
+
+pub use abi_transferable::AbiTransferable;
+pub use interface::Interface;


### PR DESCRIPTION
In a continuation of #200, this adds in the required stuff for the `windows` crate to work with the types and traits defined in `com`. This eliminates redundancy and allows us to use their features with one another.

NOTE: this PR is not ready yet as I still have some tests to fix, I am opening it beforehand so that you can let me know if you want anything done differently.