### PR TITLE
Add usize as AbiTransferable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Cargo.lock
 .DS_Store
 
 .vscode
+
+.idea

--- a/src/abi_transferable.rs
+++ b/src/abi_transferable.rs
@@ -77,6 +77,7 @@ primitive_transferable_type! {
     u64,
     f32,
     f64,
+    usize,
     crate::sys::GUID
 }
 


### PR DESCRIPTION
This commit adds usize to primitive_transferable_type macro
so that it is AbiTransferable. There are a number of pointer types
that are aliases of usize, since their size is dependent on
processor word size e.g. UINT_PTR.