### PR TITLE
Handle COM interfaces with colliding method names

### DIFF
--- a/tests/ui/pass/multiversion.rs
+++ b/tests/ui/pass/multiversion.rs
@@ -1,0 +1,44 @@
+use com::interfaces::IUnknown;
+
+com::interfaces! {
+    #[uuid("00000000-0000-0000-0000-000000000001")]
+    pub unsafe interface IFoo : IUnknown {
+        fn do_the_foo(&self) -> i32;
+    }
+
+    #[uuid("00000000-0000-0000-0000-000000000002")]
+    pub unsafe interface IFoo2 : IUnknown {
+        fn do_the_foo(&self) -> i32;
+    }
+}
+
+com::class! {
+    pub class FooWithTwoVersions : IFoo2, IFoo {
+    }
+
+    impl IFoo for FooWithTwoVersions {
+        fn do_the_foo(&self) -> i32 {
+            // The V1 behavior is to return 100
+            100
+        }
+    }
+
+    impl IFoo2 for FooWithTwoVersions {
+        fn do_the_foo(&self) -> i32 {
+            // The V2 behavior is to return 200
+            200
+        }
+    }
+}
+
+fn main() {
+    unsafe {
+        let foo_object = FooWithTwoVersions::allocate();
+
+        let foo_v1 = foo_object.query_interface::<IFoo>().unwrap();
+        assert_eq!(100, foo_v1.do_the_foo());
+
+        let foo_v2 = foo_object.query_interface::<IFoo2>().unwrap();
+        assert_eq!(200, foo_v2.do_the_foo());
+    }
+}


### PR DESCRIPTION
Resolve name collisions among methods defined on different interfaces, by
renaming some methods with a disambiguating suffix.

It is common for designers of COM interfaces to define multiple versions of
the same interface, where each new interface is a superset of the previous
version. For examples, see these DirectWrite interfaces:

* [IDWriteTextFormat](https://docs.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwritetextformat)
* [IDWriteTextFormat1](https://docs.microsoft.com/en-us/windows/win32/api/dwrite_2/nn-dwrite_2-idwritetextformat1)
* [IDWriteTextFormat2](https://docs.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritetextformat2)
* [IDWriteTextFormat3](https://docs.microsoft.com/en-us/windows/win32/api/dwrite_3/nn-dwrite_3-idwritetextformat3)

These interfaces define methods that have the same name. When implementing a
COM object in Rust, we need a way to distinguish these functions. The ugly
way is to require that different COM interface definitions avoid using the
same name, but that is clearly not feasible.

This implementation looks for name collisions, and simply renames methods
that participate in name collisions by appending the name of the interface.
If _that_ fails, then we use a numeric suffix. (We could just use the IID
as a suffix, but that's a harsh experience when debugging.)