### PR TITLE
Implement Eq and PartialEq for COM interfaces

### DIFF
--- a/macros/support/src/interface/interface.rs
+++ b/macros/support/src/interface/interface.rs
@@ -25,6 +25,7 @@ impl Interface {
             #(#docs)*
             #[repr(transparent)]
             #[derive(Debug)]
+            #[derive(PartialEq, Eq)]
             #vis struct #name {
                 inner: ::core::ptr::NonNull<#vptr>,
             }

--- a/tests/ui/pass/interface_eq.rs
+++ b/tests/ui/pass/interface_eq.rs
@@ -1,0 +1,24 @@
+use com::interfaces::IUnknown;
+
+com::interfaces! {
+    #[uuid("00000000-0000-0000-0000-000000000001")]
+    unsafe interface IFoo: IUnknown {}
+}
+
+com::class! {
+    class SimpleClass: IFoo {
+    }
+
+    impl IFoo for SimpleClass {}
+}
+
+fn main() {
+    let instance1 = SimpleClass::allocate();
+    let instance1_as_foo = instance1.query_interface::<IFoo>().unwrap();
+    let instance1_as_foo_again = instance1.query_interface::<IFoo>().unwrap();
+    assert_eq!(instance1_as_foo, instance1_as_foo_again);
+
+    let instance2 = SimpleClass::allocate();
+    let instance2_as_foo = instance2.query_interface::<IFoo>().unwrap();
+    assert_ne!(instance1_as_foo, instance2_as_foo);
+}


### PR DESCRIPTION
Pointer equality is meaningful for COM interfaces, and is often used
in COM code bases. This adds `#[derive(PartialEq, Eq)]` for generated
COM interfaces. It includes a compile test.