### PR TITLE
Increase minimum supported version to 1.46.0

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        rust: [1.42.0, stable]
+        rust: [1.46.0, stable]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
CI pipelines are failing because an indirect dependency has
increased its minimum supported Rust version, due to using `if`
inside `const fn`. Cargo currently has no way to make crate version
selections dependent on compiler version, so we are forced to raise
the minimum required version for `com-rs`.