### PR TITLE
Use atomic refcounts

### DIFF
--- a/macros/support/src/class/class_constructor.rs
+++ b/macros/support/src/class/class_constructor.rs
@@ -31,7 +31,7 @@ pub fn generate(class: &Class) -> TokenStream {
             #interface_inits
             let instance = #name {
                 #interface_fields
-                #ref_count_ident: ::core::cell::Cell::new(1),
+                #ref_count_ident: ::core::sync::atomic::AtomicU32::new(1),
                 #(#user_fields),*
             };
             let instance = ::com::alloc::boxed::Box::pin(instance);

--- a/macros/support/src/class/iunknown_impl.rs
+++ b/macros/support/src/class/iunknown_impl.rs
@@ -28,13 +28,18 @@ impl IUnknownAbi {
 
     pub fn to_release_tokens(&self) -> TokenStream {
         let this_ptr = this_ptr_type();
-        let munge = self.owned_pointer_munging();
+        let munge = self.borrowed_pointer_munging();
         let ref_count_ident = crate::utils::ref_count_ident();
 
         quote! {
             unsafe extern "system" fn Release(this: #this_ptr) -> u32 {
                 #munge
-                munged.#ref_count_ident.get().checked_sub(1).expect("Underflow of reference count")
+                let new_ref_count = ::com::release_refcount(&munged.#ref_count_ident);
+                if new_ref_count == 0 {
+                    // The last reference has been dropped.
+                    munged.drop_inner();
+                }
+                new_ref_count
             }
         }
     }
@@ -70,7 +75,7 @@ impl IUnknownAbi {
 
         quote! {
             #owned
-            let munged = ::core::mem::ManuallyDrop::new(munged);
+            let mut munged = ::core::mem::ManuallyDrop::new(munged);
         }
     }
 }
@@ -86,9 +91,7 @@ impl IUnknown {
         let ref_count_ident = crate::utils::ref_count_ident();
         quote! {
             pub unsafe fn AddRef(self: &::core::pin::Pin<::com::alloc::boxed::Box<Self>>) -> u32 {
-                let value = self.#ref_count_ident.get().checked_add(1).expect("Overflow of reference count");
-                self.#ref_count_ident.set(value);
-                value
+                ::com::addref_refcount(&self.#ref_count_ident)
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,3 +120,61 @@ extern crate self as com;
 // for code that uses `#![no_std]`.
 #[doc(hidden)]
 pub extern crate alloc;
+
+/// Panics, because an `IUnknown::Release()` call has underflowed.
+///
+/// This function is never inlined, so it keeps the (some what verbose)
+/// machinery of calling the panic handler out of mainline code, which is
+/// inlined in many places. This also gives us a very convenient call stack
+/// in a debugger.
+///
+#[doc(hidden)]
+#[inline(never)]
+fn release_refcount_underflow() -> ! {
+    panic!("IUnknown::Release called, but refcount was zero");
+}
+
+// We check for u32::MAX / 2, instead of u32::MAX, to guard against AddRef attacks.
+const REFCOUNT_OVERFLOW_MAX: u32 = u32::MAX / 2;
+
+#[doc(hidden)]
+#[inline(always)]
+pub fn release_refcount(ref_count: &core::sync::atomic::AtomicU32) -> u32 {
+    let old_ref_count = ref_count.fetch_sub(1, ::core::sync::atomic::Ordering::SeqCst);
+    if old_ref_count == 0 {
+        // The reference count was invalid.
+        // In safe Rust, this should be impossible.
+        // Of course, other clients outside of safe Rust can use COM.
+        ::com::release_refcount_underflow();
+    } else {
+        old_ref_count - 1
+    }
+}
+
+/// We do our best to harden code against `AddRef` attacks. An `AddRef` attack
+/// is one that intentionally overflows a reference count, so that a `Release`
+/// call can be used to destroy an object, even though other references are
+/// still outstanding.
+#[doc(hidden)]
+#[inline(always)]
+pub fn addref_refcount(ref_count: &core::sync::atomic::AtomicU32) -> u32 {
+    let old_ref_count = ref_count.fetch_add(1, ::core::sync::atomic::Ordering::SeqCst);
+    if old_ref_count >= REFCOUNT_OVERFLOW_MAX {
+        // Undo the increment that we just performed.
+        let _ = ref_count.fetch_sub(1, ::core::sync::atomic::Ordering::SeqCst);
+        addref_overflow();
+    } else {
+        old_ref_count + 1
+    }
+}
+
+/// Panics, because an `IUnknown::AddRef()` call has overflowed.
+///
+/// This function is never inlined, so it keeps the (some what verbose)
+/// machinery of calling the panic handler out of mainline code, which is
+/// inlined in many places. This also gives us a very convenient call stack
+/// in a debugger.
+#[inline(never)]
+fn addref_overflow() -> ! {
+    panic!("IUnknown::AddRef: refcount has overflowed");
+}


### PR DESCRIPTION
This upgrades all refcounts to use `AtomicU32` instead of `Cell<u32>`. This makes all COM server implementations thread-safe, at least as far as memory lifetime goes.

Ideally, the `com::class!` macro should allow class implementations to control whether they want thread-safe refcounts or not. Until then, it's best to err on the side of being conservative.
