### PR TITLE
macros/class: Fix HashSet contains+inserts pair to only lookup once

### DIFF
--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -85,13 +85,11 @@ impl Class {
             let chain_ident = interface.chain_ident(index);
             let ref_count_ident = crate::utils::ref_count_ident();
 
-            for interface_path in interface.iter_chain() {
+            for interface_path in interface
+                .iter_chain()
                 // Avoid generating duplicate From implementations
-                if interfaces_seen.contains(interface_path) {
-                    continue;
-                }
-                interfaces_seen.insert(interface_path);
-
+                .filter(|interface_path| interfaces_seen.insert(interface_path))
+            {
                 output.extend(quote! {
                     impl<'a> ::core::convert::From<&'a #class_name> for #interface_path {
                         fn from(class: &'a #class_name) -> Self {


### PR DESCRIPTION
Overlooked style nit from https://github.com/microsoft/com-rs/pull/224/files#r732498255 that both makes the code more pretty to read as per the suggestion from @rylev, _and_ by using the boolean result from `.insert()` no second lookup with `.contains()` needs to be performed, shaving some cylces off.

---

Test: `cargo t --all` remains successful with this.  Commenting out the `.filter()` line makes some tests fail.

CC @sivadeilra