### PR TITLE
Hide some implementation details from docs

### DIFF
--- a/macros/support/src/interface/iid.rs
+++ b/macros/support/src/interface/iid.rs
@@ -46,6 +46,7 @@ impl IID {
         let data4_8 = hex_lit(data4_8);
         quote!(
             #[allow(missing_docs)]
+            #[doc(hidden)]
             pub const #iid_ident: com::sys::IID = com::sys::IID {
                 data1: #data1,
                 data2: #data2,

--- a/macros/support/src/interface/vptr.rs
+++ b/macros/support/src/interface/vptr.rs
@@ -10,6 +10,7 @@ pub fn generate(interface: &Interface) -> TokenStream {
 
     quote!(
         #[allow(missing_docs)]
+        #[doc(hidden)]
         #vis type #vptr_ident = ::core::ptr::NonNull<#vtable_ident>;
     )
 }

--- a/macros/support/src/interface/vtable.rs
+++ b/macros/support/src/interface/vtable.rs
@@ -23,6 +23,7 @@ pub fn generate(interface: &Interface) -> syn::Result<TokenStream> {
     Ok(quote!(
         #[allow(non_snake_case, missing_docs)]
         #[repr(C)]
+        #[doc(hidden)]
         #vis struct #vtable_ident {
             #parent_field
             #methods


### PR DESCRIPTION
This adds `#[doc(hidden)]` to several generated items: the vtable
statics for classes, the IID for interfaces, and a type alias.

This makes `cargo doc` a lot cleaner.