### PR TITLE
macros/class: Propagate `cfg` annotations to COM class methods

### DIFF
--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -625,7 +625,9 @@ impl Interface {
                 }
             };
             let field_name = Ident::new(&crate::utils::snake_to_camel(&original_name.to_string()), proc_macro2::Span::call_site());
+            let attrs = &m.item.attrs;
             quote! {
+                #(#attrs)*
                 #field_name: {
                     #method
                     #name

--- a/macros/support/src/class/class.rs
+++ b/macros/support/src/class/class.rs
@@ -145,7 +145,7 @@ impl Class {
             }
             interfaces.push(interface);
 
-            let mut current = interfaces.last_mut().unwrap();
+            let current = interfaces.last_mut().unwrap();
             fn parse_parens(buffer: &ParseBuffer, current: &mut Interface) -> syn::Result<()> {
                 while buffer.peek(syn::token::Paren) {
                     let contents;
@@ -161,7 +161,7 @@ impl Class {
                 Ok(())
             }
 
-            parse_parens(input, &mut current)?;
+            parse_parens(input, current)?;
 
             if !input.peek(syn::token::Brace) {
                 let _ = input.parse::<syn::Token!(,)>()?;

--- a/src/production.rs
+++ b/src/production.rs
@@ -1,5 +1,4 @@
 mod class;
-#[cfg(windows)]
 #[doc(hidden)]
 #[cfg(windows)]
 pub mod registration;


### PR DESCRIPTION
We have a very peculiar workaround for DXC (pending upstream ~fix~ solution microsoft/DirectXShaderCompiler#3793) that requires us to conditionally provide function implementations for extra vtable "spacers": https://github.com/Traverse-Research/hassle-rs/blob/f5a090c70bbcf66f3bafd3d549716a414e873838/src/wrapper.rs#L130-L139.  The spacers are conditionally defined in: https://github.com/Traverse-Research/hassle-rs/blob/f5a090c70bbcf66f3bafd3d549716a414e873838/src/unknown.rs.

These need to be forwarded otherwise the initialization of these vtable members will happen unconditionally even when they don't exist: https://github.com/Traverse-Research/hassle-rs/actions/runs/1777800733

Fixes #166
